### PR TITLE
Add web-based MicroPython IDE for Stepico devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# Code
-Try to use codex to write code
+# Stepico MicroPython 在线 IDE
+
+这是一个面向 Stepico 系列 RP2040 设备（兼容 Raspberry Pi Pico）的纯前端在线 IDE。它通过浏览器 Web Serial API 直接和设备进行 USB 通信，提供类似 Thonny 的核心操作体验。
+
+## 功能特性
+- ✅ Monaco 风格（基于 CodeMirror）代码编辑器，内置语法高亮与快捷键
+- ✅ 一键连接 Stepico / Pico 主控板、游戏机或 12 指神探调试工具
+- ✅ 执行当前脚本（Raw REPL）并在终端窗口查看输出
+- ✅ 将脚本写入设备 `main.py`，上电自动运行
+- ✅ 交互式 REPL 输入，支持 Ctrl+C 中断
+- ✅ 将编辑区代码导出到本地
+
+## 使用方式
+1. 启动本地静态服务器，例如：
+   ```bash
+   python -m http.server 8080
+   ```
+2. 在支持 Web Serial 的浏览器（Chrome 89+、Edge 89+ 等）访问 `http://localhost:8080`。
+3. 点击“连接”，在弹窗中选择 Stepico 设备（USB VID `0x2E8A`）。
+4. 通过编辑器编写 MicroPython 代码：
+   - `Ctrl+R` / `Ctrl+Enter` 运行脚本
+   - `Ctrl+S` 下载当前脚本到电脑
+   - 点击“保存为 main.py”写入设备
+   - 终端中输入命令并回车，可与设备交互
+
+> ⚠️ 由于浏览器安全策略，Web Serial 只能在 HTTPS 或 `http://localhost` 环境下使用。
+
+## 兼容性说明
+- Stepico 核心板完全沿用了 Pico 的 USB 描述符，因此可直接识别。
+- 游戏机和 12 指神探工具如同串口设备一样连接；如需自定义滤波，可在 `app.js` 的 `picoFilters` 中补充 VID/PID。
+- 本工具完全在浏览器本地运行，无需后端服务，适合集成到企业官网或教育平台。
+
+## 开发建议
+- 如需定制界面，可修改 `style.css`。
+- 如需扩展文件管理、固件烧录等高级功能，可继续在 `app.js` 基础上开发。
+

--- a/app.js
+++ b/app.js
@@ -1,0 +1,273 @@
+const terminalEl = document.getElementById("terminal");
+const statusEl = document.getElementById("status");
+const connectBtn = document.getElementById("connect");
+const disconnectBtn = document.getElementById("disconnect");
+const runBtn = document.getElementById("run");
+const stopBtn = document.getElementById("stop");
+const uploadBtn = document.getElementById("upload");
+const downloadBtn = document.getElementById("download");
+const replForm = document.getElementById("repl-form");
+const replInput = document.getElementById("repl-input");
+const boardSelector = document.getElementById("board");
+
+const editor = CodeMirror.fromTextArea(document.getElementById("editor"), {
+  mode: "python",
+  theme: "material-darker",
+  lineNumbers: true,
+  indentUnit: 4,
+  tabSize: 4,
+  lineWrapping: true,
+  extraKeys: {
+    "Ctrl-Enter": () => runCurrentScript(),
+    "Ctrl-R": () => runCurrentScript(),
+    "Ctrl-S": () => saveToComputer(),
+  },
+});
+
+editor.setValue(`# Stepico MicroPython 示例
+from machine import Pin
+import time
+
+led = Pin(25, Pin.OUT)
+
+while True:
+    led.toggle()
+    time.sleep(0.5)
+`);
+
+class MicroPythonConnection {
+  constructor(onData) {
+    this.onData = onData;
+    this.port = null;
+    this.reader = null;
+    this.writer = null;
+    this.keepReading = false;
+  }
+
+  async connect(filters) {
+    if (!("serial" in navigator)) {
+      throw new Error("当前浏览器不支持 Web Serial，请使用最新版 Chrome、Edge 或基于 Chromium 的浏览器，并确保通过 HTTPS 或 localhost 访问。");
+    }
+
+    this.port = await navigator.serial.requestPort({ filters });
+    await this.port.open({ baudRate: 115200 });
+
+    const textDecoder = new TextDecoderStream();
+    this.readableStreamClosed = this.port.readable.pipeTo(textDecoder.writable);
+    this.reader = textDecoder.readable.getReader();
+
+    const textEncoder = new TextEncoderStream();
+    this.writableStreamClosed = textEncoder.readable.pipeTo(this.port.writable);
+    this.writer = textEncoder.writable.getWriter();
+
+    this.keepReading = true;
+    this.readLoop();
+    await this.softReset();
+  }
+
+  async disconnect() {
+    this.keepReading = false;
+    if (this.reader) {
+      await this.reader.cancel().catch(() => {});
+      this.reader = null;
+    }
+    if (this.writer) {
+      await this.writer.close().catch(() => {});
+      this.writer = null;
+    }
+    if (this.readableStreamClosed) {
+      await this.readableStreamClosed.catch(() => {});
+    }
+    if (this.writableStreamClosed) {
+      await this.writableStreamClosed.catch(() => {});
+    }
+    if (this.port) {
+      await this.port.close().catch(() => {});
+      this.port = null;
+    }
+  }
+
+  async readLoop() {
+    while (this.keepReading && this.reader) {
+      try {
+        const { value, done } = await this.reader.read();
+        if (done) break;
+        if (value) {
+          this.onData(value);
+        }
+      } catch (err) {
+        console.error("读取串口数据失败", err);
+        this.onData(`\n[错误] ${err.message}\n`);
+        break;
+      }
+    }
+  }
+
+  async writeRaw(data) {
+    if (!this.writer) {
+      throw new Error("尚未连接到设备");
+    }
+    await this.writer.write(data);
+  }
+
+  async softReset() {
+    await this.writeRaw("\x03\x03");
+    await this.delay(100);
+    await this.writeRaw("\r");
+  }
+
+  async enterRawRepl() {
+    await this.writeRaw("\x01");
+    await this.delay(100);
+  }
+
+  async exitRawRepl() {
+    await this.writeRaw("\x02");
+    await this.delay(100);
+  }
+
+  async runScript(code) {
+    await this.enterRawRepl();
+    await this.delay(100);
+    await this.writeRaw(code + "\x04");
+    await this.delay(200);
+    await this.exitRawRepl();
+  }
+
+  async uploadMainPy(code) {
+    const base64 = btoa(unescape(encodeURIComponent(code)));
+    const uploader = `import ubinascii\ndata = ubinascii.a2b_base64("${base64}")\nwith open('main.py','wb') as f:\n    f.write(data)\nprint('写入 main.py 完成')\n`;
+    await this.runScript(uploader);
+  }
+
+  async sendRepl(line) {
+    await this.writeRaw(line + "\r");
+  }
+
+  async stopExecution() {
+    await this.writeRaw("\x03");
+  }
+
+  delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+const picoFilters = [
+  { usbVendorId: 0x2e8a }, // Raspberry Pi / Stepico
+];
+
+const connection = new MicroPythonConnection((data) => appendTerminal(data));
+
+function appendTerminal(message, type = "log-output") {
+  if (!message) return;
+  const span = document.createElement("span");
+  span.className = type;
+  span.textContent = message;
+  terminalEl.appendChild(span);
+  terminalEl.appendChild(document.createElement("br"));
+  terminalEl.scrollTop = terminalEl.scrollHeight;
+}
+
+function setStatus(text) {
+  statusEl.textContent = text;
+}
+
+function setConnectedState(isConnected) {
+  connectBtn.disabled = isConnected;
+  disconnectBtn.disabled = !isConnected;
+  runBtn.disabled = !isConnected;
+  stopBtn.disabled = !isConnected;
+  uploadBtn.disabled = !isConnected;
+  replInput.disabled = !isConnected;
+  replForm.querySelector("button").disabled = !isConnected;
+}
+
+async function connectToBoard() {
+  try {
+    appendTerminal(`[信息] 正在请求连接 ${boardSelector.value}...`, "log-info");
+    await connection.connect(picoFilters);
+    setStatus("已连接");
+    appendTerminal("[信息] 连接成功，已进入 MicroPython REPL", "log-info");
+    setConnectedState(true);
+  } catch (err) {
+    appendTerminal(`[错误] ${err.message}`, "log-error");
+    setStatus("未连接");
+  }
+}
+
+async function disconnectBoard() {
+  await connection.disconnect();
+  setStatus("未连接");
+  setConnectedState(false);
+  appendTerminal("[信息] 已断开连接", "log-info");
+}
+
+async function runCurrentScript() {
+  if (runBtn.disabled) return;
+  try {
+    appendTerminal("[信息] 正在运行脚本...", "log-info");
+    await connection.runScript(editor.getValue());
+  } catch (err) {
+    appendTerminal(`[错误] ${err.message}`, "log-error");
+  }
+}
+
+async function uploadMainPy() {
+  if (uploadBtn.disabled) return;
+  try {
+    appendTerminal("[信息] 正在写入 main.py...", "log-info");
+    await connection.uploadMainPy(editor.getValue());
+    appendTerminal("[信息] main.py 写入完成。重新上电或复位后将自动运行。", "log-info");
+  } catch (err) {
+    appendTerminal(`[错误] ${err.message}`, "log-error");
+  }
+}
+
+async function sendReplCommand(event) {
+  event.preventDefault();
+  if (!replInput.value.trim()) return;
+  const command = replInput.value;
+  replInput.value = "";
+  appendTerminal(">>> " + command, "log-info");
+  try {
+    await connection.sendRepl(command);
+  } catch (err) {
+    appendTerminal(`[错误] ${err.message}`, "log-error");
+  }
+}
+
+async function stopExecution() {
+  try {
+    await connection.stopExecution();
+    appendTerminal("[信息] 已发送中断指令 (Ctrl+C)", "log-info");
+  } catch (err) {
+    appendTerminal(`[错误] ${err.message}`, "log-error");
+  }
+}
+
+function saveToComputer() {
+  const blob = new Blob([editor.getValue()], { type: "text/x-python" });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = "stepico_script.py";
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
+connectBtn.addEventListener("click", connectToBoard);
+disconnectBtn.addEventListener("click", disconnectBoard);
+runBtn.addEventListener("click", runCurrentScript);
+stopBtn.addEventListener("click", stopExecution);
+uploadBtn.addEventListener("click", uploadMainPy);
+downloadBtn.addEventListener("click", saveToComputer);
+replForm.addEventListener("submit", sendReplCommand);
+
+window.addEventListener("beforeunload", () => {
+  if (connection.port) {
+    connection.disconnect();
+  }
+});
+
+appendTerminal("欢迎使用 Stepico 在线 IDE。请点击“连接”并允许浏览器访问设备。", "log-info");
+setConnectedState(false);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stepico MicroPython IDE</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/lib/codemirror.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/theme/material-darker.min.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="app-header">
+    <h1>Stepico MicroPython IDE</h1>
+    <div class="board-selector">
+      <label for="board">目标设备:</label>
+      <select id="board">
+        <option value="pico">Stepico / Raspberry Pi Pico</option>
+        <option value="console">Stepico Game Console</option>
+        <option value="debugger">12指神探调试工具</option>
+      </select>
+    </div>
+  </header>
+
+  <main class="layout">
+    <section class="editor-pane">
+      <div class="editor-toolbar">
+        <button id="connect" class="primary">连接</button>
+        <button id="disconnect" disabled>断开</button>
+        <button id="run" disabled>运行 (Ctrl+R)</button>
+        <button id="stop" disabled>中断 (Ctrl+C)</button>
+        <button id="upload" disabled>保存为 main.py</button>
+        <button id="download">导出脚本</button>
+        <span class="status" id="status">未连接</span>
+      </div>
+      <textarea id="editor"></textarea>
+    </section>
+
+    <section class="terminal-pane">
+      <header>
+        <h2>终端</h2>
+      </header>
+      <div id="terminal"></div>
+      <form id="repl-form">
+        <input type="text" id="repl-input" placeholder=">>>" autocomplete="off" disabled />
+        <button type="submit" disabled>发送</button>
+      </form>
+    </section>
+  </main>
+
+  <footer>
+    <p>通过 USB 与 Stepico 系列设备通信，兼容 Thonny 常用操作。</p>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/lib/codemirror.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/mode/python/python.min.js"></script>
+  <script src="app.js" type="module"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,179 @@
+:root {
+  color-scheme: dark;
+  --bg: #121212;
+  --panel: #1f1f1f;
+  --accent: #00bcd4;
+  --text: #f1f5f9;
+  --muted: #94a3b8;
+  --danger: #f87171;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background-color: var(--bg);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-header {
+  padding: 1rem 2rem;
+  background: linear-gradient(90deg, #263238, #1f2937);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.board-selector select {
+  background-color: var(--panel);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text);
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  gap: 1rem;
+  flex: 1;
+  padding: 1rem 2rem 2rem;
+}
+
+.editor-pane,
+.terminal-pane {
+  background-color: var(--panel);
+  border-radius: 1rem;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+}
+
+.editor-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.editor-toolbar button {
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background-color: transparent;
+  color: var(--text);
+  cursor: pointer;
+  transition: background-color 0.2s, transform 0.2s;
+}
+
+.editor-toolbar button.primary {
+  background: var(--accent);
+  border-color: transparent;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.editor-toolbar button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.editor-toolbar button:not(:disabled):hover {
+  background-color: rgba(0, 188, 212, 0.15);
+  transform: translateY(-1px);
+}
+
+.editor-toolbar .status {
+  margin-left: auto;
+  color: var(--muted);
+}
+
+.CodeMirror {
+  flex: 1;
+  height: calc(100% - 1rem);
+  background-color: transparent;
+  font-size: 15px;
+  padding: 0 1rem 1rem;
+}
+
+.terminal-pane header {
+  padding: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+#terminal {
+  padding: 1rem;
+  flex: 1;
+  overflow-y: auto;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+#terminal .log-info {
+  color: var(--muted);
+}
+
+#terminal .log-error {
+  color: var(--danger);
+}
+
+#terminal .log-output {
+  color: var(--text);
+}
+
+#repl-form {
+  display: flex;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+#repl-form input {
+  flex: 1;
+  padding: 0.6rem 0.9rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background-color: rgba(255, 255, 255, 0.05);
+  color: var(--text);
+}
+
+#repl-form button {
+  padding: 0.6rem 1.2rem;
+  border-radius: 0.75rem;
+  border: none;
+  background-color: var(--accent);
+  color: #0f172a;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  color: var(--muted);
+}
+
+@media (max-width: 1080px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static Stepico MicroPython IDE with CodeMirror editor and Web Serial based device communication
- style the interface with a dark theme layout and control toolbar mirroring common Thonny actions
- document usage, compatibility, and customization guidance for Stepico/Pico boards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbe88855208326b698485bf5bf133a