### PR TITLE
Add Flask HTML editor with upload and preview features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# Code
-Try to use codex to write code
+# HTML 在线编辑器
+
+一个可以上传、在线编辑并实时预览 HTML 文件的简易 Web 应用。
+
+## 功能特性
+
+- 上传 `.html` 或 `.htm` 文件后即可在线编辑。
+- 支持一键预览，在同一页面内实时查看渲染效果。
+- 保存时会覆盖原文件，保持原文件名不变。
+- 记录已上传的文件，方便后续再次编辑。
+
+## 快速开始
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+应用默认运行在 [http://localhost:5000](http://localhost:5000)。
+
+## 项目结构
+
+```
+.
+├── app.py              # Flask 应用入口
+├── requirements.txt    # 依赖列表
+├── templates/          # Jinja2 模板
+├── static/             # 前端静态资源
+└── uploads/            # 保存上传的 HTML 文件
+```
+
+## 注意事项
+
+- 单个文件上传大小限制为 16MB。
+- 仅支持上传 HTML 文件，为保证安全会对文件名进行过滤。

--- a/app.py
+++ b/app.py
@@ -1,0 +1,76 @@
+import os
+from pathlib import Path
+from flask import Flask, render_template, request, redirect, url_for, jsonify, abort
+from werkzeug.utils import secure_filename
+
+BASE_DIR = Path(__file__).resolve().parent
+UPLOAD_DIR = BASE_DIR / "uploads"
+UPLOAD_DIR.mkdir(exist_ok=True)
+
+ALLOWED_EXTENSIONS = {"html", "htm"}
+
+app = Flask(__name__)
+app.config["MAX_CONTENT_LENGTH"] = 16 * 1024 * 1024  # 16MB upload limit
+
+
+def allowed_file(filename: str) -> bool:
+    return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+def get_file_path(filename: str) -> Path:
+    safe_name = secure_filename(filename)
+    if not safe_name:
+        abort(400, "Invalid filename")
+    file_path = UPLOAD_DIR / safe_name
+    if not file_path.exists():
+        abort(404, "File not found")
+    return file_path
+
+
+@app.route("/")
+def index():
+    files = sorted(p.name for p in UPLOAD_DIR.glob("*.htm")) + sorted(
+        p.name for p in UPLOAD_DIR.glob("*.html")
+    )
+    return render_template("index.html", files=files)
+
+
+@app.post("/upload")
+def upload():
+    uploaded_file = request.files.get("file")
+    if uploaded_file is None or uploaded_file.filename == "":
+        return redirect(url_for("index"))
+
+    if not allowed_file(uploaded_file.filename):
+        abort(400, "Only HTML files are allowed")
+
+    filename = secure_filename(uploaded_file.filename)
+    if not filename:
+        abort(400, "Invalid filename")
+
+    file_path = UPLOAD_DIR / filename
+    uploaded_file.save(file_path)
+    return redirect(url_for("edit", filename=filename))
+
+
+@app.get("/edit/<path:filename>")
+def edit(filename: str):
+    file_path = get_file_path(filename)
+    content = file_path.read_text(encoding="utf-8")
+    return render_template("editor.html", filename=file_path.name, content=content)
+
+
+@app.post("/save/<path:filename>")
+def save(filename: str):
+    file_path = get_file_path(filename)
+    data = request.get_json(silent=True) or {}
+    content = data.get("content")
+    if content is None:
+        abort(400, "Missing content")
+
+    file_path.write_text(content, encoding="utf-8")
+    return jsonify({"status": "success", "message": f"Saved {file_path.name}"})
+
+
+if __name__ == "__main__":
+    app.run(debug=True, host="0.0.0.0", port=int(os.environ.get("PORT", 5000)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask>=3.0.0
+werkzeug>=3.0.0

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,16 @@
+body {
+  font-family: "Noto Sans SC", "Helvetica Neue", Arial, sans-serif;
+}
+
+#editor {
+  min-height: 60vh;
+  font-family: "JetBrains Mono", "Fira Code", Consolas, "Courier New", monospace;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  white-space: pre;
+}
+
+#preview-frame {
+  border: 0;
+  background-color: #fff;
+}

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -1,0 +1,58 @@
+const editor = document.getElementById('editor');
+const saveButton = document.getElementById('save-button');
+const previewButton = document.getElementById('preview-button');
+const previewFrame = document.getElementById('preview-frame');
+const saveStatus = document.getElementById('save-status');
+
+const filenameMeta = document.querySelector('meta[name="filename"]');
+const filename = filenameMeta ? filenameMeta.getAttribute('content') : null;
+
+const updatePreview = () => {
+  const doc = previewFrame.contentDocument || previewFrame.contentWindow.document;
+  doc.open();
+  doc.write(editor.value);
+  doc.close();
+};
+
+const showStatus = (message, type = 'info') => {
+  saveStatus.textContent = message;
+  saveStatus.className = type === 'success' ? 'text-success small pt-2' : type === 'error' ? 'text-danger small pt-2' : 'text-muted small pt-2';
+};
+
+if (previewButton) {
+  previewButton.addEventListener('click', (event) => {
+    event.preventDefault();
+    updatePreview();
+  });
+}
+
+if (saveButton && filename) {
+  saveButton.addEventListener('click', async () => {
+    showStatus('保存中...');
+    try {
+      const response = await fetch(`/save/${encodeURIComponent(filename)}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ content: editor.value })
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(errorText || '保存失败');
+      }
+
+      const data = await response.json();
+      showStatus(data.message || '保存成功', 'success');
+    } catch (error) {
+      console.error(error);
+      showStatus(error.message || '保存时发生错误', 'error');
+    }
+  });
+}
+
+// Initialize preview with current content
+if (editor && previewFrame) {
+  updatePreview();
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}HTML Editor{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    {% block head %}{% endblock %}
+  </head>
+  <body class="bg-light min-vh-100">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('index') }}">HTML 在线编辑器</a>
+      </div>
+    </nav>
+    <main class="container mb-5">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          {% for category, message in messages %}
+            <div class="alert alert-{{ category }}">{{ message }}</div>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </main>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    {% block scripts %}{% endblock %}
+  </body>
+</html>

--- a/templates/editor.html
+++ b/templates/editor.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+
+{% block title %}编辑 {{ filename }} - HTML Editor{% endblock %}
+
+{% block head %}
+  <meta name="filename" content="{{ filename }}">
+{% endblock %}
+
+{% block content %}
+  <div class="row">
+    <div class="col-12 col-lg-6 mb-4 mb-lg-0">
+      <div class="card shadow-sm h-100">
+        <div class="card-body d-flex flex-column">
+          <div class="d-flex justify-content-between align-items-center mb-3">
+            <h1 class="h4 mb-0">编辑 {{ filename }}</h1>
+            <div class="btn-group" role="group">
+              <button id="save-button" class="btn btn-success">保存</button>
+              <button id="preview-button" class="btn btn-outline-primary">预览</button>
+            </div>
+          </div>
+          <textarea id="editor" class="form-control flex-grow-1" spellcheck="false">{{ content }}</textarea>
+          <div id="save-status" class="text-muted small pt-2"></div>
+        </div>
+      </div>
+    </div>
+    <div class="col-12 col-lg-6">
+      <div class="card shadow-sm h-100">
+        <div class="card-body">
+          <h2 class="h5">实时预览</h2>
+          <div class="ratio ratio-4x3 border rounded overflow-hidden">
+            <iframe id="preview-frame" title="HTML Preview"></iframe>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ url_for('static', filename='js/editor.js') }}" defer></script>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block title %}上传 HTML 文件 - HTML Editor{% endblock %}
+
+{% block content %}
+  <div class="row justify-content-center">
+    <div class="col-lg-8">
+      <div class="card shadow-sm">
+        <div class="card-body">
+          <h1 class="h4 mb-4">上传 HTML 文件进行编辑</h1>
+          <form action="{{ url_for('upload') }}" method="post" enctype="multipart/form-data" class="mb-4">
+            <div class="input-group">
+              <input class="form-control" type="file" name="file" accept=".html,.htm" required>
+              <button class="btn btn-primary" type="submit">上传并编辑</button>
+            </div>
+          </form>
+          {% if files %}
+            <h2 class="h5">已上传的文件</h2>
+            <ul class="list-group">
+              {% for file in files %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                  <span>{{ file }}</span>
+                  <a class="btn btn-outline-primary btn-sm" href="{{ url_for('edit', filename=file) }}">继续编辑</a>
+                </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="text-muted mb-0">还没有上传的 HTML 文件。</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement a Flask web application to upload, edit, save, and preview HTML files
- add responsive templates, styling, and client-side logic for real-time preview and status messaging
- document setup steps and project structure in the README

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dd32b530388326bed767bcbd95e177