### PR TITLE
Add FPGA Selection Agent MVP with server, APIs, scoring engine, UI, data and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+coverage

--- a/README.md
+++ b/README.md
@@ -1,2 +1,134 @@
-# Code
-Try to use codex to write code
+# FPGA Selection Agent MVP
+
+这是一个**可直接本地运行**的 FPGA 选型智能体 MVP。
+
+它已经内置：
+- 自然语言需求解析
+- 参数约束过滤
+- 多维评分排序
+- 推荐理由 / 风险 / 替代器件 / 开发板建议
+- 原型阶段 vs 量产阶段差异化建议
+
+> 当前环境无法访问 npm registry，所以这个 MVP 采用 **零外部运行时依赖** 实现；你**不需要 `npm install`**，直接运行即可。
+
+---
+
+## 一分钟启动
+
+### 方式 1：直接启动
+```bash
+node server.mjs
+```
+
+### 方式 2：使用启动脚本
+```bash
+bash scripts/run-agent.sh
+```
+
+启动后打开：
+```bash
+http://localhost:3000
+```
+
+---
+
+## 如何确认它真的跑起来了
+
+另开一个终端，执行：
+
+```bash
+bash scripts/smoke-test.sh
+```
+
+如果服务正常，你会看到：
+- `GET /api/devices` 返回器件列表
+- `POST /api/selection/recommend` 返回推荐结果
+- 最后输出 `[Smoke Test] PASS`
+
+---
+
+## 常用命令
+
+### 运行服务
+```bash
+node server.mjs
+```
+
+### 代码检查
+```bash
+npm run build
+npm run typecheck
+npm test
+```
+
+### API 冒烟验证
+```bash
+bash scripts/smoke-test.sh
+```
+
+---
+
+## 页面里可以做什么
+
+打开首页后，你可以：
+- 输入自然语言需求
+- 选择场景模板
+- 添加 LUT / DSP / BRAM / GPIO / 功耗 / 价格带等约束
+- 勾选 MIPI / PCIe / DDR / Hard CPU 等硬需求
+- 查看：
+  - Top N 推荐器件
+  - 推荐理由
+  - 风险提示
+  - 更便宜替代器件
+  - 更适合量产的替代器件
+  - 开发板建议
+  - Prototype vs Production 差异
+  - 评分拆解
+
+---
+
+## 内置 API
+
+- `POST /api/selection/parse`
+- `POST /api/selection/search`
+- `POST /api/selection/rank`
+- `POST /api/selection/recommend`
+- `GET /api/devices`
+- `GET /api/devices/:id`
+
+示例：
+
+```bash
+curl -s -X POST http://localhost:3000/api/selection/recommend \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"Linux 边缘网关，偏向 SoC FPGA","topN":2}'
+```
+
+---
+
+## 项目结构
+
+- `app/`：页面与 API handler 入口
+- `components/`：页面结构组件
+- `lib/data/`：器件、场景、开发板数据
+- `lib/parser/`：需求解析
+- `lib/rules/`：专家规则
+- `lib/scoring/`：过滤、评分、解释
+- `tests/`：自动化测试
+- `scripts/`：启动与冒烟脚本
+
+---
+
+## 说明
+
+如果你现在看到的只是 PR diff 截图，而不是运行中的页面，请直接在仓库根目录执行：
+
+```bash
+bash scripts/run-agent.sh
+```
+
+然后用浏览器访问：
+
+```bash
+http://localhost:3000
+```

--- a/app/api/devices/[id]/route.js
+++ b/app/api/devices/[id]/route.js
@@ -1,0 +1,2 @@
+import { getDeviceDetails } from '../../../../lib/selection-service.js';
+export function handleDeviceById(id) { return getDeviceDetails(id); }

--- a/app/api/devices/route.js
+++ b/app/api/devices/route.js
@@ -1,0 +1,2 @@
+import { listDevices } from '../../../lib/selection-service.js';
+export function handleDevices() { return listDevices(); }

--- a/app/api/selection/parse/route.js
+++ b/app/api/selection/parse/route.js
@@ -1,0 +1,2 @@
+import { parseOnly } from '../../../../lib/selection-service.js';
+export function handleParse(body) { return parseOnly(body); }

--- a/app/api/selection/rank/route.js
+++ b/app/api/selection/rank/route.js
@@ -1,0 +1,2 @@
+import { rankSelection } from '../../../../lib/selection-service.js';
+export function handleRank(body) { return rankSelection(body); }

--- a/app/api/selection/recommend/route.js
+++ b/app/api/selection/recommend/route.js
@@ -1,0 +1,2 @@
+import { recommendSelection } from '../../../../lib/selection-service.js';
+export function handleRecommend(body) { return recommendSelection(body); }

--- a/app/api/selection/search/route.js
+++ b/app/api/selection/search/route.js
@@ -1,0 +1,2 @@
+import { searchDevices } from '../../../../lib/selection-service.js';
+export function handleSearch(body) { return searchDevices(body); }

--- a/app/page.js
+++ b/app/page.js
@@ -1,0 +1,15 @@
+import { renderLayout } from '../components/layout.js';
+import { renderHomePage } from '../components/home-page.js';
+import { listApplicationProfiles } from '../lib/selection-service.js';
+
+const demos = [
+  '低功耗 MIPI 双摄桥接模块，工业级，预算敏感',
+  '需要 PCIe Gen3 和 DDR4 的数据采集卡',
+  '用于高校教学的低成本 FPGA 开发板选型',
+  'Linux 边缘网关，偏向 SoC FPGA',
+  '工业电机控制，要求低功耗和长期供货'
+];
+
+export function renderIndexPage() {
+  return renderLayout(renderHomePage({ demos, applications: listApplicationProfiles() }));
+}

--- a/components/home-page.js
+++ b/components/home-page.js
@@ -1,0 +1,84 @@
+export function renderHomePage({ demos, applications }) {
+  return `
+  <main class="page-shell">
+    <section class="hero">
+      <div>
+        <p class="eyebrow">FPGA Selection Agent · MVP</p>
+        <h1>面向工程决策的 FPGA 选型智能体</h1>
+        <p class="hero-copy">把应用理解、硬约束过滤、多维评分和风险解释串成一条完整推荐链路，而不是只做参数筛选。</p>
+      </div>
+      <div class="hero-card">
+        <h2>本版增强</h2>
+        <ul>
+          <li>解析 PCIe / DDR 代际与团队技能风险</li>
+          <li>输出原型阶段 vs 量产阶段差异建议</li>
+          <li>展示 Top 结果、替代器件与维度评分</li>
+          <li>保留 Next.js 风格目录，当前零依赖可运行</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="grid two-col">
+      <div class="panel">
+        <h2>需求输入</h2>
+        <form id="selection-form" class="stack-lg">
+          <label class="stack-sm">
+            <span>自然语言需求</span>
+            <textarea id="query" name="query" rows="5" placeholder="例如：低功耗 MIPI 双摄桥接模块，工业级，预算敏感"></textarea>
+          </label>
+
+          <div class="grid form-grid">
+            <label><span>场景模板</span><select id="applicationId" name="applicationId"><option value="">自动识别</option>${applications.map((app) => `<option value="${app.id}">${app.title}</option>`).join('')}</select></label>
+            <label><span>Top N</span><input id="topN" name="topN" type="number" min="1" max="5" value="3" /></label>
+            <label><span>当前阶段</span><select id="stage" name="stage"><option value="prototype">Prototype</option><option value="production">Production</option></select></label>
+            <label><span>预算敏感度</span><select id="budget_sensitivity" name="budget_sensitivity"><option value="high">High</option><option value="medium" selected>Medium</option><option value="low">Low</option></select></label>
+            <label><span>团队经验</span><select id="fpga_experience" name="fpga_experience"><option value="beginner">Beginner</option><option value="intermediate" selected>Intermediate</option><option value="advanced">Advanced</option></select></label>
+            <label><span>目标温度等级</span><select id="target_temp_grade" name="target_temp_grade"><option value="commercial">Commercial</option><option value="industrial">Industrial</option></select></label>
+            <label><span>最小 LUT</span><input id="min_luts" name="min_luts" type="number" min="0" value="0" /></label>
+            <label><span>最小 DSP</span><input id="min_dsp_blocks" name="min_dsp_blocks" type="number" min="0" value="0" /></label>
+            <label><span>最小 BRAM(KB)</span><input id="min_bram_kb" name="min_bram_kb" type="number" min="0" value="0" /></label>
+            <label><span>最小 GPIO</span><input id="min_gpio_count" name="min_gpio_count" type="number" min="0" value="0" /></label>
+            <label><span>最大价格带</span><select id="max_price_band" name="max_price_band"><option value="low">Low</option><option value="mid" selected>Mid</option><option value="high">High</option></select></label>
+            <label><span>最大功耗等级</span><select id="max_power_profile" name="max_power_profile"><option value="ultra_low">Ultra Low</option><option value="low">Low</option><option value="medium" selected>Medium</option><option value="high">High</option></select></label>
+          </div>
+
+          <div class="check-grid">
+            <label><input type="checkbox" id="require_mipi" /> Require MIPI</label>
+            <label><input type="checkbox" id="require_pcie" /> Require PCIe</label>
+            <label><input type="checkbox" id="require_ddr" /> Require DDR</label>
+            <label><input type="checkbox" id="require_hard_cpu" /> Require Hard CPU</label>
+            <label><input type="checkbox" id="prioritize_supply" /> Prioritize Supply</label>
+            <label><input type="checkbox" id="prioritize_longevity" /> Prioritize Longevity</label>
+            <label><input type="checkbox" id="ddr_experience" /> Team knows DDR</label>
+            <label><input type="checkbox" id="serdes_experience" /> Team knows SerDes</label>
+            <label><input type="checkbox" id="linux_experience" /> Team knows Linux</label>
+          </div>
+
+          <div class="actions">
+            <button type="submit">生成推荐</button>
+            <button type="button" id="load-demo">载入示例</button>
+          </div>
+        </form>
+      </div>
+
+      <div class="panel">
+        <h2>Demo 用例</h2>
+        <div class="stack-sm demo-list">
+          ${demos.map((demo, index) => `<button class="demo-item" data-demo-index="${index}"><strong>${index + 1}.</strong> ${demo}</button>`).join('')}
+        </div>
+        <h2>产品说明</h2>
+        <ul class="stack-sm muted-list">
+          <li>应用场景优先于单点参数。</li>
+          <li>团队能力会影响推荐排名与风险提示。</li>
+          <li>原型与量产阶段会得到不同建议。</li>
+          <li>工具链、社区和开发板成熟度参与决策。</li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="status" class="status">等待输入需求。</section>
+    <section id="parsed-panel" class="panel hidden"></section>
+    <section id="comparison-panel" class="panel hidden"></section>
+    <section id="results-panel" class="panel hidden"></section>
+  </main>`;
+}

--- a/components/layout.js
+++ b/components/layout.js
@@ -1,0 +1,15 @@
+export function renderLayout(content) {
+  return `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FPGA Selection Agent MVP</title>
+  <link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+  ${content}
+  <script type="module" src="/app.js"></script>
+</body>
+</html>`;
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,27 @@
+# API
+
+## POST /api/selection/parse
+Input: `SelectionRequest`
+Output: `ParsedConstraints`
+Purpose: parse natural language and infer scenario, interfaces, stage, and skill gaps.
+
+## POST /api/selection/search
+Input: `SelectionRequest`
+Output: filtered `FPGADevice[]`
+Purpose: apply hard constraints before scoring.
+
+## POST /api/selection/rank
+Input: `SelectionRequest`
+Output: ranked results without full recommendation text.
+Purpose: inspect score breakdowns and compare devices.
+
+## POST /api/selection/recommend
+Input: `SelectionRequest`
+Output: `SelectionResponse`
+Purpose: end-to-end decision support with explanations, alternatives, boards, and risks.
+
+## GET /api/devices
+Output: all sample devices.
+
+## GET /api/devices/:id
+Output: single device plus suggested boards.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,25 @@
+# Architecture
+
+## Runtime shape
+This MVP uses a lightweight Node HTTP server to expose JSON APIs and render a responsive web UI. The codebase keeps a Next.js-style directory layout (`app`, `components`, `lib`, `types`, `docs`) so it can be migrated to Next.js when package installation is available.
+
+## Layers
+- `lib/data`: local FPGA dataset, application templates, board metadata
+- `lib/parser`: natural-language parsing and request normalization
+- `lib/rules`: expert rule adjustments and stage/team heuristics
+- `lib/scoring`: filtering, weighted scoring, explanation generation
+- `app/api`: endpoint handlers mapped by the Node server
+- `components`: HTML component renderers for UI sections
+- `app`: page assembly and client-side orchestration
+
+## Request pipeline
+1. Client submits `SelectionRequest`
+2. Parser derives `ParsedConstraints` and scenario signals
+3. Filter removes devices that fail hard constraints
+4. Rules adjust scoring weights and penalties
+5. Scoring engine computes per-dimension scores
+6. Explanation engine builds reasons, risks, alternatives, and board guidance
+7. Response returns ranked `SelectionResult[]`
+
+## Migration path
+The domain, scoring, and API handler modules are framework-agnostic. They can move into Next.js route handlers and React components with minimal changes.

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -1,0 +1,16 @@
+# Data Model
+
+## Core entities
+- `FPGADevice`: normalized device metadata and capabilities.
+- `BoardRecommendation`: development board candidate tied to a device or family.
+- `ApplicationProfile`: scenario template with default weights and preferred/avoided traits.
+- `SelectionRequest`: end-user request containing natural language, structured constraints, team profile, and business context.
+- `ParsedConstraints`: normalized filters and inferred scenario/application signals.
+- `ScoreBreakdown`: weighted component scores plus notes.
+- `SelectionResult`: ranked device recommendation with explanations and alternatives.
+
+## Modeling principles
+- Keep numeric resources normalized in consistent units.
+- Represent hard IP features explicitly (`pcie_support`, `ddr_support`, `mipi_support`, `hard_cpu`).
+- Keep supply, lifecycle, cost, and ecosystem data alongside technical features so business trade-offs can be scored.
+- Store `recommended_for` and `not_recommended_for` tags for application-aware reasoning.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,34 @@
+# FPGA Selection Agent PRD
+
+## Goal
+Build a runnable MVP that helps engineers, teachers, students, and product teams choose FPGA devices using application intent, hard constraints, team capability, and business context.
+
+## Primary users
+- Embedded and FPGA engineers
+- University instructors and students
+- Hardware product managers
+- R&D sourcing or platform teams
+
+## Core user flows
+1. Enter a natural-language project brief and optional structured constraints.
+2. Parse request into application profile, resource requirements, interface needs, and team/business context.
+3. Filter devices by hard constraints.
+4. Rank remaining devices with configurable weighted scoring.
+5. Return Top N recommendations, alternatives, risks, toolchain guidance, and board suggestions.
+
+## MVP scope
+- Local sample dataset for six vendors.
+- Five API-style endpoints for parse, search, rank, recommend, and device lookup.
+- Single-page web UI for input, recommendations, comparison, and explanations.
+- Built-in demo scenarios and sample queries.
+
+## Non-goals
+- Real-time distributor inventory
+- LLM-based free-form reasoning over external web data
+- User authentication or persistence
+
+## Success criteria
+- App starts locally with one command.
+- Demo queries return differentiated, explainable recommendations.
+- Prototype vs. production stage changes ranking behavior.
+- Team skills and toolchain preferences affect results.

--- a/docs/SCORING_MODEL.md
+++ b/docs/SCORING_MODEL.md
@@ -1,0 +1,27 @@
+# Scoring Model
+
+## Dimensions and default weights
+- ApplicationFit: 0.30
+- ResourceFit: 0.20
+- InterfaceFit: 0.15
+- ToolchainFit: 0.10
+- BoardFeasibility: 0.10
+- CostFit: 0.05
+- SupplyLifecycleFit: 0.05
+- CommunityFit: 0.05
+
+## Rule adjustments
+- Education lowers emphasis on high-end/high-speed devices and boosts board feasibility/cost.
+- Prototype raises board feasibility and tool maturity.
+- Production raises lifecycle, availability, and long-term supply weighting.
+- Low-experience teams get penalties for devices requiring DDR/SerDes-heavy board work.
+- Linux/SoC use cases boost hard CPU support.
+- Vision bridge use cases boost MIPI support, power efficiency, and compact packages.
+
+## Explanation policy
+Every result explains:
+- why it matched the scenario
+- major advantages
+- key risks
+- why it outranks the second-place result
+- cheaper and production-oriented alternatives

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,13 @@
+# TODO
+
+## Near-term
+- Replace heuristics with configurable parser rules or DSL.
+- Add more realistic board catalog and family variants.
+- Extend supply model with distributor and lead-time snapshots.
+- Add CSV/JSON import tooling for larger device datasets.
+- Migrate Node-rendered UI into real Next.js + React components when dependency installation is available.
+
+## Validation
+- Add unit tests for parsing, filtering, and scoring.
+- Add regression cases for each scenario template.
+- Add snapshot fixtures for recommendation explanations.

--- a/lib/data/applications.js
+++ b/lib/data/applications.js
@@ -1,0 +1,7 @@
+import applicationProfiles from './applications.json' with { type: 'json' };
+
+export { applicationProfiles };
+
+export function getApplicationProfile(id) {
+  return applicationProfiles.find((profile) => profile.id === id) || applicationProfiles.find((profile) => profile.id === 'cost_optimized_general');
+}

--- a/lib/data/applications.json
+++ b/lib/data/applications.json
@@ -1,0 +1,196 @@
+[
+  {
+    "id": "education_entry",
+    "title": "Education Entry",
+    "description": "Low-cost teaching, labs, and first FPGA bring-up with mature boards and tooling.",
+    "defaultWeights": {
+      "ApplicationFit": 0.2,
+      "ResourceFit": 0.1,
+      "InterfaceFit": 0.05,
+      "ToolchainFit": 0.15,
+      "BoardFeasibility": 0.25,
+      "CostFit": 0.15,
+      "SupplyLifecycleFit": 0.05,
+      "CommunityFit": 0.05
+    },
+    "preferredTraits": [
+      "education",
+      "board_maturity",
+      "low_cost",
+      "community"
+    ],
+    "avoidedTraits": [
+      "serdes_heavy",
+      "high_complexity"
+    ]
+  },
+  {
+    "id": "embedded_vision_bridge",
+    "title": "Embedded Vision Bridge",
+    "description": "MIPI/LVDS camera bridging, ISP glue logic, and compact low-power video interface designs.",
+    "defaultWeights": {
+      "ApplicationFit": 0.3,
+      "ResourceFit": 0.15,
+      "InterfaceFit": 0.25,
+      "ToolchainFit": 0.05,
+      "BoardFeasibility": 0.1,
+      "CostFit": 0.05,
+      "SupplyLifecycleFit": 0.05,
+      "CommunityFit": 0.05
+    },
+    "preferredTraits": [
+      "vision",
+      "mipi",
+      "low_power",
+      "small_package"
+    ],
+    "avoidedTraits": [
+      "high_power",
+      "oversized"
+    ]
+  },
+  {
+    "id": "industrial_control",
+    "title": "Industrial Control",
+    "description": "Motor control, PLC auxiliaries, deterministic IO, and long-lifecycle industrial automation.",
+    "defaultWeights": {
+      "ApplicationFit": 0.28,
+      "ResourceFit": 0.17,
+      "InterfaceFit": 0.1,
+      "ToolchainFit": 0.08,
+      "BoardFeasibility": 0.1,
+      "CostFit": 0.07,
+      "SupplyLifecycleFit": 0.15,
+      "CommunityFit": 0.05
+    },
+    "preferredTraits": [
+      "industrial",
+      "low_power",
+      "longevity",
+      "io_rich"
+    ],
+    "avoidedTraits": [
+      "bleeding_edge",
+      "consumer_only"
+    ]
+  },
+  {
+    "id": "pcie_data_acquisition",
+    "title": "PCIe Data Acquisition",
+    "description": "High-throughput capture cards needing PCIe, DDR buffering, and often transceivers.",
+    "defaultWeights": {
+      "ApplicationFit": 0.28,
+      "ResourceFit": 0.22,
+      "InterfaceFit": 0.22,
+      "ToolchainFit": 0.08,
+      "BoardFeasibility": 0.05,
+      "CostFit": 0.03,
+      "SupplyLifecycleFit": 0.07,
+      "CommunityFit": 0.05
+    },
+    "preferredTraits": [
+      "pcie",
+      "ddr",
+      "serdes",
+      "high_bandwidth"
+    ],
+    "avoidedTraits": [
+      "low_end",
+      "no_ddr"
+    ]
+  },
+  {
+    "id": "low_power_edge_ai",
+    "title": "Low Power Edge AI",
+    "description": "Sensor fusion and lightweight edge inference under power and thermal limits.",
+    "defaultWeights": {
+      "ApplicationFit": 0.32,
+      "ResourceFit": 0.2,
+      "InterfaceFit": 0.12,
+      "ToolchainFit": 0.08,
+      "BoardFeasibility": 0.1,
+      "CostFit": 0.08,
+      "SupplyLifecycleFit": 0.05,
+      "CommunityFit": 0.05
+    },
+    "preferredTraits": [
+      "edge_ai",
+      "low_power",
+      "dsp",
+      "mipi"
+    ],
+    "avoidedTraits": [
+      "high_power"
+    ]
+  },
+  {
+    "id": "linux_soc_gateway",
+    "title": "Linux SoC Gateway",
+    "description": "Embedded Linux gateways favoring hard CPUs, DDR, and mixed communication interfaces.",
+    "defaultWeights": {
+      "ApplicationFit": 0.3,
+      "ResourceFit": 0.15,
+      "InterfaceFit": 0.16,
+      "ToolchainFit": 0.1,
+      "BoardFeasibility": 0.08,
+      "CostFit": 0.05,
+      "SupplyLifecycleFit": 0.1,
+      "CommunityFit": 0.06
+    },
+    "preferredTraits": [
+      "linux",
+      "hard_cpu",
+      "ddr",
+      "ecosystem"
+    ],
+    "avoidedTraits": [
+      "soft_cpu_only"
+    ]
+  },
+  {
+    "id": "cost_optimized_general",
+    "title": "Cost Optimized General",
+    "description": "General-purpose control and interface logic where BOM and availability dominate.",
+    "defaultWeights": {
+      "ApplicationFit": 0.22,
+      "ResourceFit": 0.18,
+      "InterfaceFit": 0.1,
+      "ToolchainFit": 0.1,
+      "BoardFeasibility": 0.1,
+      "CostFit": 0.18,
+      "SupplyLifecycleFit": 0.07,
+      "CommunityFit": 0.05
+    },
+    "preferredTraits": [
+      "low_cost",
+      "available",
+      "moderate_io"
+    ],
+    "avoidedTraits": [
+      "premium_only"
+    ]
+  },
+  {
+    "id": "high_speed_connectivity",
+    "title": "High Speed Connectivity",
+    "description": "Bridging or packet processing using multi-gigabit serial links and high-speed IO.",
+    "defaultWeights": {
+      "ApplicationFit": 0.28,
+      "ResourceFit": 0.18,
+      "InterfaceFit": 0.24,
+      "ToolchainFit": 0.08,
+      "BoardFeasibility": 0.05,
+      "CostFit": 0.03,
+      "SupplyLifecycleFit": 0.07,
+      "CommunityFit": 0.07
+    },
+    "preferredTraits": [
+      "serdes",
+      "pcie",
+      "high_bandwidth"
+    ],
+    "avoidedTraits": [
+      "entry_level"
+    ]
+  }
+]

--- a/lib/data/boards.js
+++ b/lib/data/boards.js
@@ -1,0 +1,7 @@
+import boardCatalog from './boards.json' with { type: 'json' };
+
+export { boardCatalog };
+
+export function boardsForDevice(deviceId) {
+  return boardCatalog.filter((board) => board.device_ids.includes(deviceId));
+}

--- a/lib/data/boards.json
+++ b/lib/data/boards.json
@@ -1,0 +1,146 @@
+[
+  {
+    "id": "digilent-cmod-a7",
+    "name": "Digilent Cmod A7",
+    "vendor": "Digilent",
+    "device_ids": [
+      "amd-artix-7-35t"
+    ],
+    "stage_focus": [
+      "prototype"
+    ],
+    "summary": "Mature education board for basic RTL, IO labs, and entry teaching.",
+    "price_band": "low",
+    "maturity_score": 9
+  },
+  {
+    "id": "qmtech-zynq-7010",
+    "name": "QMTech Zynq-7010 SoM",
+    "vendor": "QMTech",
+    "device_ids": [
+      "amd-zynq-7010"
+    ],
+    "stage_focus": [
+      "prototype",
+      "production"
+    ],
+    "summary": "Low-cost Linux-capable SoC module for gateway and control prototypes.",
+    "price_band": "mid",
+    "maturity_score": 7
+  },
+  {
+    "id": "trenz-te0725",
+    "name": "Trenz TE0725",
+    "vendor": "Trenz",
+    "device_ids": [
+      "amd-zynqmp-zu3eg"
+    ],
+    "stage_focus": [
+      "prototype",
+      "production"
+    ],
+    "summary": "Industrial-friendly MPSoC module for Linux gateways and vision edge nodes.",
+    "price_band": "high",
+    "maturity_score": 8
+  },
+  {
+    "id": "terasic-de10-nano",
+    "name": "Terasic DE10-Nano",
+    "vendor": "Terasic",
+    "device_ids": [
+      "intel-cyclone-v-soc"
+    ],
+    "stage_focus": [
+      "prototype"
+    ],
+    "summary": "Popular education and embedded Linux SoC FPGA board with large community.",
+    "price_band": "mid",
+    "maturity_score": 9
+  },
+  {
+    "id": "enclustra-mercury-xu5",
+    "name": "Enclustra Mercury XU5",
+    "vendor": "Enclustra",
+    "device_ids": [
+      "amd-kintex-ultrascale-ku040"
+    ],
+    "stage_focus": [
+      "prototype",
+      "production"
+    ],
+    "summary": "High-speed mezzanine platform suited for PCIe and interface-heavy work.",
+    "price_band": "high",
+    "maturity_score": 8
+  },
+  {
+    "id": "lattice-crosslink-nx-evn",
+    "name": "CrossLink-NX Evaluation Board",
+    "vendor": "Lattice",
+    "device_ids": [
+      "lattice-crosslink-nx-17"
+    ],
+    "stage_focus": [
+      "prototype"
+    ],
+    "summary": "Vision bridge evaluation kit for MIPI and low-power camera aggregation.",
+    "price_band": "mid",
+    "maturity_score": 8
+  },
+  {
+    "id": "microchip-polarfire-icicle",
+    "name": "PolarFire Icicle Kit",
+    "vendor": "Microchip",
+    "device_ids": [
+      "microchip-polarfire-soc-mpfs250t"
+    ],
+    "stage_focus": [
+      "prototype",
+      "production"
+    ],
+    "summary": "Long-lifecycle Linux SoC kit with industrial and security-oriented ecosystem.",
+    "price_band": "high",
+    "maturity_score": 8
+  },
+  {
+    "id": "efinix-titanium-ti60",
+    "name": "Efinix Titanium Ti60 F225 Dev Kit",
+    "vendor": "Efinix",
+    "device_ids": [
+      "efinix-titanium-ti60"
+    ],
+    "stage_focus": [
+      "prototype"
+    ],
+    "summary": "Compact low-power platform for edge AI and sensor processing exploration.",
+    "price_band": "mid",
+    "maturity_score": 6
+  },
+  {
+    "id": "gowin-tang-nano-20k",
+    "name": "Sipeed Tang Nano 20K",
+    "vendor": "Sipeed",
+    "device_ids": [
+      "gowin-gw2ar-18"
+    ],
+    "stage_focus": [
+      "prototype"
+    ],
+    "summary": "Very low-cost board for teaching and small control projects.",
+    "price_band": "low",
+    "maturity_score": 7
+  },
+  {
+    "id": "intel-agilex-devkit",
+    "name": "Intel Agilex Development Kit",
+    "vendor": "Intel",
+    "device_ids": [
+      "intel-agilex-7-f"
+    ],
+    "stage_focus": [
+      "prototype"
+    ],
+    "summary": "Premium platform for PCIe Gen4-class and transceiver-heavy prototyping.",
+    "price_band": "high",
+    "maturity_score": 7
+  }
+]

--- a/lib/data/devices.js
+++ b/lib/data/devices.js
@@ -1,0 +1,7 @@
+import devices from './devices.json' with { type: 'json' };
+
+export { devices };
+
+export function getDeviceById(id) {
+  return devices.find((device) => device.id === id);
+}

--- a/lib/data/devices.json
+++ b/lib/data/devices.json
@@ -1,0 +1,648 @@
+[
+  {
+    "id": "amd-artix-7-35t",
+    "vendor": "AMD",
+    "family": "Artix-7",
+    "part_number": "XC7A35T-1CPG236C",
+    "device_type": "FPGA",
+    "logic_cells": 33280,
+    "luts": 20800,
+    "ffs": 41600,
+    "bram_kb": 1800,
+    "uram_kb": 0,
+    "dsp_blocks": 90,
+    "transceiver_channels": 0,
+    "transceiver_max_rate_gbps": 0,
+    "pcie_support": null,
+    "ddr_support": [
+      "DDR3"
+    ],
+    "mipi_support": false,
+    "hard_cpu": false,
+    "gpio_count": 210,
+    "lvds_pairs": 24,
+    "package_options": [
+      "CPG236"
+    ],
+    "temp_grades": [
+      "commercial",
+      "industrial"
+    ],
+    "power_profile": "low",
+    "toolchain": [
+      "Vivado"
+    ],
+    "lifecycle_status": "mature",
+    "price_band": "low",
+    "availability_score": 8,
+    "community_score": 9,
+    "board_maturity_score": 10,
+    "board_complexity": "low",
+    "recommended_for": [
+      "education",
+      "industrial",
+      "general_io"
+    ],
+    "not_recommended_for": [
+      "pcie",
+      "linux",
+      "serdes_heavy"
+    ]
+  },
+  {
+    "id": "amd-zynq-7010",
+    "vendor": "AMD",
+    "family": "Zynq-7000",
+    "part_number": "XC7Z010-1CLG400I",
+    "device_type": "SoC FPGA",
+    "logic_cells": 28000,
+    "luts": 17600,
+    "ffs": 35200,
+    "bram_kb": 2400,
+    "uram_kb": 0,
+    "dsp_blocks": 80,
+    "transceiver_channels": 0,
+    "transceiver_max_rate_gbps": 0,
+    "pcie_support": null,
+    "ddr_support": [
+      "DDR3",
+      "DDR3L"
+    ],
+    "mipi_support": false,
+    "hard_cpu": true,
+    "gpio_count": 180,
+    "lvds_pairs": 20,
+    "package_options": [
+      "CLG400"
+    ],
+    "temp_grades": [
+      "commercial",
+      "industrial"
+    ],
+    "power_profile": "medium",
+    "toolchain": [
+      "Vivado",
+      "PetaLinux"
+    ],
+    "lifecycle_status": "mature",
+    "price_band": "mid",
+    "availability_score": 8,
+    "community_score": 9,
+    "board_maturity_score": 9,
+    "board_complexity": "medium",
+    "recommended_for": [
+      "linux",
+      "gateway",
+      "education",
+      "industrial"
+    ],
+    "not_recommended_for": [
+      "ultra_low_power",
+      "high_speed_serdes"
+    ]
+  },
+  {
+    "id": "amd-zynqmp-zu3eg",
+    "vendor": "AMD",
+    "family": "Zynq UltraScale+",
+    "part_number": "XCZU3EG-1SFVC784I",
+    "device_type": "SoC FPGA",
+    "logic_cells": 154000,
+    "luts": 70500,
+    "ffs": 141000,
+    "bram_kb": 7600,
+    "uram_kb": 0,
+    "dsp_blocks": 360,
+    "transceiver_channels": 4,
+    "transceiver_max_rate_gbps": 6,
+    "pcie_support": "Gen2 x4",
+    "ddr_support": [
+      "DDR4",
+      "LPDDR4"
+    ],
+    "mipi_support": true,
+    "hard_cpu": true,
+    "gpio_count": 220,
+    "lvds_pairs": 28,
+    "package_options": [
+      "SFVC784"
+    ],
+    "temp_grades": [
+      "industrial"
+    ],
+    "power_profile": "medium",
+    "toolchain": [
+      "Vivado",
+      "Vitis",
+      "PetaLinux"
+    ],
+    "lifecycle_status": "active",
+    "price_band": "high",
+    "availability_score": 7,
+    "community_score": 8,
+    "board_maturity_score": 8,
+    "board_complexity": "high",
+    "recommended_for": [
+      "linux",
+      "vision",
+      "edge_ai",
+      "gateway"
+    ],
+    "not_recommended_for": [
+      "budget_sensitive",
+      "entry_education"
+    ]
+  },
+  {
+    "id": "amd-kintex-ultrascale-ku040",
+    "vendor": "AMD",
+    "family": "Kintex UltraScale",
+    "part_number": "XCKU040-2FFVA1156I",
+    "device_type": "FPGA",
+    "logic_cells": 242000,
+    "luts": 138000,
+    "ffs": 276000,
+    "bram_kb": 21600,
+    "uram_kb": 0,
+    "dsp_blocks": 1920,
+    "transceiver_channels": 16,
+    "transceiver_max_rate_gbps": 16.3,
+    "pcie_support": "Gen3 x8",
+    "ddr_support": [
+      "DDR4"
+    ],
+    "mipi_support": false,
+    "hard_cpu": false,
+    "gpio_count": 520,
+    "lvds_pairs": 64,
+    "package_options": [
+      "FFVA1156"
+    ],
+    "temp_grades": [
+      "industrial"
+    ],
+    "power_profile": "high",
+    "toolchain": [
+      "Vivado"
+    ],
+    "lifecycle_status": "active",
+    "price_band": "high",
+    "availability_score": 6,
+    "community_score": 7,
+    "board_maturity_score": 7,
+    "board_complexity": "high",
+    "recommended_for": [
+      "pcie",
+      "data_acquisition",
+      "high_speed_connectivity"
+    ],
+    "not_recommended_for": [
+      "education",
+      "low_power",
+      "budget_sensitive"
+    ]
+  },
+  {
+    "id": "intel-cyclone-10-lp",
+    "vendor": "Intel",
+    "family": "Cyclone 10 LP",
+    "part_number": "10CL025YU256I7G",
+    "device_type": "Low Power FPGA",
+    "logic_cells": 24624,
+    "luts": 16000,
+    "ffs": 32000,
+    "bram_kb": 1400,
+    "uram_kb": 0,
+    "dsp_blocks": 66,
+    "transceiver_channels": 0,
+    "transceiver_max_rate_gbps": 0,
+    "pcie_support": null,
+    "ddr_support": [
+      "DDR3"
+    ],
+    "mipi_support": false,
+    "hard_cpu": false,
+    "gpio_count": 220,
+    "lvds_pairs": 30,
+    "package_options": [
+      "U256"
+    ],
+    "temp_grades": [
+      "industrial"
+    ],
+    "power_profile": "low",
+    "toolchain": [
+      "Quartus Prime"
+    ],
+    "lifecycle_status": "active",
+    "price_band": "low",
+    "availability_score": 8,
+    "community_score": 7,
+    "board_maturity_score": 7,
+    "board_complexity": "low",
+    "recommended_for": [
+      "education",
+      "industrial",
+      "general_io",
+      "cost_optimized"
+    ],
+    "not_recommended_for": [
+      "pcie",
+      "linux",
+      "mipi_bridge"
+    ]
+  },
+  {
+    "id": "intel-cyclone-v-soc",
+    "vendor": "Intel",
+    "family": "Cyclone V SoC",
+    "part_number": "5CSEBA6U23I7",
+    "device_type": "SoC FPGA",
+    "logic_cells": 110000,
+    "luts": 56000,
+    "ffs": 112000,
+    "bram_kb": 5530,
+    "uram_kb": 0,
+    "dsp_blocks": 224,
+    "transceiver_channels": 0,
+    "transceiver_max_rate_gbps": 0,
+    "pcie_support": null,
+    "ddr_support": [
+      "DDR3"
+    ],
+    "mipi_support": false,
+    "hard_cpu": true,
+    "gpio_count": 340,
+    "lvds_pairs": 40,
+    "package_options": [
+      "U23"
+    ],
+    "temp_grades": [
+      "industrial"
+    ],
+    "power_profile": "medium",
+    "toolchain": [
+      "Quartus Prime"
+    ],
+    "lifecycle_status": "mature",
+    "price_band": "mid",
+    "availability_score": 7,
+    "community_score": 9,
+    "board_maturity_score": 9,
+    "board_complexity": "medium",
+    "recommended_for": [
+      "linux",
+      "education",
+      "gateway",
+      "control"
+    ],
+    "not_recommended_for": [
+      "pcie_gen3",
+      "ultra_low_power"
+    ]
+  },
+  {
+    "id": "intel-agilex-7-f",
+    "vendor": "Intel",
+    "family": "Agilex 7",
+    "part_number": "AGFB014R24B2E2V",
+    "device_type": "FPGA",
+    "logic_cells": 614000,
+    "luts": 320000,
+    "ffs": 640000,
+    "bram_kb": 53200,
+    "uram_kb": 0,
+    "dsp_blocks": 3680,
+    "transceiver_channels": 24,
+    "transceiver_max_rate_gbps": 28.9,
+    "pcie_support": "Gen4 x8",
+    "ddr_support": [
+      "DDR4",
+      "LPDDR4"
+    ],
+    "mipi_support": false,
+    "hard_cpu": false,
+    "gpio_count": 640,
+    "lvds_pairs": 72,
+    "package_options": [
+      "R24"
+    ],
+    "temp_grades": [
+      "commercial"
+    ],
+    "power_profile": "high",
+    "toolchain": [
+      "Quartus Prime Pro"
+    ],
+    "lifecycle_status": "new",
+    "price_band": "high",
+    "availability_score": 5,
+    "community_score": 6,
+    "board_maturity_score": 6,
+    "board_complexity": "high",
+    "recommended_for": [
+      "pcie",
+      "high_speed_connectivity",
+      "data_acquisition"
+    ],
+    "not_recommended_for": [
+      "education",
+      "budget_sensitive",
+      "low_power"
+    ]
+  },
+  {
+    "id": "lattice-crosslink-nx-17",
+    "vendor": "Lattice",
+    "family": "CrossLink-NX",
+    "part_number": "LIFCL-17-8SG72CES",
+    "device_type": "Low Power FPGA",
+    "logic_cells": 17000,
+    "luts": 17000,
+    "ffs": 18000,
+    "bram_kb": 824,
+    "uram_kb": 0,
+    "dsp_blocks": 56,
+    "transceiver_channels": 0,
+    "transceiver_max_rate_gbps": 0,
+    "pcie_support": null,
+    "ddr_support": [],
+    "mipi_support": true,
+    "hard_cpu": false,
+    "gpio_count": 150,
+    "lvds_pairs": 12,
+    "package_options": [
+      "SG72"
+    ],
+    "temp_grades": [
+      "industrial"
+    ],
+    "power_profile": "ultra_low",
+    "toolchain": [
+      "Lattice Radiant"
+    ],
+    "lifecycle_status": "active",
+    "price_band": "mid",
+    "availability_score": 7,
+    "community_score": 7,
+    "board_maturity_score": 8,
+    "board_complexity": "medium",
+    "recommended_for": [
+      "vision",
+      "mipi_bridge",
+      "low_power_edge_ai"
+    ],
+    "not_recommended_for": [
+      "pcie",
+      "linux",
+      "high_logic_density"
+    ]
+  },
+  {
+    "id": "lattice-ecp5-45",
+    "vendor": "Lattice",
+    "family": "ECP5",
+    "part_number": "LFE5U-45F-6BG381I",
+    "device_type": "FPGA",
+    "logic_cells": 44000,
+    "luts": 44000,
+    "ffs": 44000,
+    "bram_kb": 2088,
+    "uram_kb": 0,
+    "dsp_blocks": 156,
+    "transceiver_channels": 4,
+    "transceiver_max_rate_gbps": 3.2,
+    "pcie_support": "Soft Gen2 x1",
+    "ddr_support": [
+      "DDR3"
+    ],
+    "mipi_support": false,
+    "hard_cpu": false,
+    "gpio_count": 240,
+    "lvds_pairs": 24,
+    "package_options": [
+      "BG381"
+    ],
+    "temp_grades": [
+      "industrial"
+    ],
+    "power_profile": "low",
+    "toolchain": [
+      "Lattice Diamond",
+      "open-source"
+    ],
+    "lifecycle_status": "active",
+    "price_band": "mid",
+    "availability_score": 8,
+    "community_score": 8,
+    "board_maturity_score": 8,
+    "board_complexity": "medium",
+    "recommended_for": [
+      "education",
+      "industrial",
+      "cost_optimized",
+      "connectivity"
+    ],
+    "not_recommended_for": [
+      "linux_hard_cpu",
+      "gen3_pcie"
+    ]
+  },
+  {
+    "id": "microchip-polarfire-soc-mpfs250t",
+    "vendor": "Microchip",
+    "family": "PolarFire SoC",
+    "part_number": "MPFS250T-FCVG484I",
+    "device_type": "SoC FPGA",
+    "logic_cells": 254000,
+    "luts": 95000,
+    "ffs": 190000,
+    "bram_kb": 7200,
+    "uram_kb": 0,
+    "dsp_blocks": 784,
+    "transceiver_channels": 8,
+    "transceiver_max_rate_gbps": 12.7,
+    "pcie_support": "Gen2 x4",
+    "ddr_support": [
+      "DDR4"
+    ],
+    "mipi_support": false,
+    "hard_cpu": true,
+    "gpio_count": 300,
+    "lvds_pairs": 34,
+    "package_options": [
+      "FCVG484"
+    ],
+    "temp_grades": [
+      "industrial"
+    ],
+    "power_profile": "medium",
+    "toolchain": [
+      "Libero SoC"
+    ],
+    "lifecycle_status": "active",
+    "price_band": "high",
+    "availability_score": 8,
+    "community_score": 6,
+    "board_maturity_score": 8,
+    "board_complexity": "high",
+    "recommended_for": [
+      "linux",
+      "industrial",
+      "gateway",
+      "long_lifecycle"
+    ],
+    "not_recommended_for": [
+      "entry_education",
+      "low_budget"
+    ]
+  },
+  {
+    "id": "microchip-polarfire-mpfa100t",
+    "vendor": "Microchip",
+    "family": "PolarFire",
+    "part_number": "MPFA100T-FCG484I",
+    "device_type": "FPGA",
+    "logic_cells": 109000,
+    "luts": 60000,
+    "ffs": 120000,
+    "bram_kb": 4800,
+    "uram_kb": 0,
+    "dsp_blocks": 300,
+    "transceiver_channels": 8,
+    "transceiver_max_rate_gbps": 12.7,
+    "pcie_support": "Gen2 x4",
+    "ddr_support": [
+      "DDR4"
+    ],
+    "mipi_support": false,
+    "hard_cpu": false,
+    "gpio_count": 284,
+    "lvds_pairs": 32,
+    "package_options": [
+      "FCG484"
+    ],
+    "temp_grades": [
+      "industrial"
+    ],
+    "power_profile": "low",
+    "toolchain": [
+      "Libero SoC"
+    ],
+    "lifecycle_status": "active",
+    "price_band": "high",
+    "availability_score": 8,
+    "community_score": 6,
+    "board_maturity_score": 7,
+    "board_complexity": "high",
+    "recommended_for": [
+      "industrial",
+      "data_acquisition",
+      "low_power_high_speed"
+    ],
+    "not_recommended_for": [
+      "education",
+      "budget_sensitive"
+    ]
+  },
+  {
+    "id": "efinix-titanium-ti60",
+    "vendor": "Efinix",
+    "family": "Titanium",
+    "part_number": "T60F225C4",
+    "device_type": "FPGA",
+    "logic_cells": 62700,
+    "luts": 62700,
+    "ffs": 85000,
+    "bram_kb": 4320,
+    "uram_kb": 0,
+    "dsp_blocks": 184,
+    "transceiver_channels": 4,
+    "transceiver_max_rate_gbps": 3.125,
+    "pcie_support": "Soft Gen2 x1",
+    "ddr_support": [
+      "LPDDR4",
+      "DDR4"
+    ],
+    "mipi_support": true,
+    "hard_cpu": false,
+    "gpio_count": 220,
+    "lvds_pairs": 18,
+    "package_options": [
+      "F225"
+    ],
+    "temp_grades": [
+      "commercial",
+      "industrial"
+    ],
+    "power_profile": "low",
+    "toolchain": [
+      "Efinity"
+    ],
+    "lifecycle_status": "active",
+    "price_band": "mid",
+    "availability_score": 6,
+    "community_score": 5,
+    "board_maturity_score": 6,
+    "board_complexity": "medium",
+    "recommended_for": [
+      "edge_ai",
+      "vision",
+      "cost_optimized"
+    ],
+    "not_recommended_for": [
+      "maximum_ecosystem",
+      "gen3_pcie"
+    ]
+  },
+  {
+    "id": "gowin-gw2ar-18",
+    "vendor": "Gowin",
+    "family": "Arora V",
+    "part_number": "GW2AR-LV18QN88C8/I7",
+    "device_type": "Low Power FPGA",
+    "logic_cells": 18000,
+    "luts": 18000,
+    "ffs": 22000,
+    "bram_kb": 720,
+    "uram_kb": 0,
+    "dsp_blocks": 64,
+    "transceiver_channels": 0,
+    "transceiver_max_rate_gbps": 0,
+    "pcie_support": null,
+    "ddr_support": [
+      "DDR3"
+    ],
+    "mipi_support": false,
+    "hard_cpu": false,
+    "gpio_count": 140,
+    "lvds_pairs": 10,
+    "package_options": [
+      "QN88"
+    ],
+    "temp_grades": [
+      "commercial",
+      "industrial"
+    ],
+    "power_profile": "low",
+    "toolchain": [
+      "Gowin EDA"
+    ],
+    "lifecycle_status": "active",
+    "price_band": "low",
+    "availability_score": 6,
+    "community_score": 5,
+    "board_maturity_score": 7,
+    "board_complexity": "low",
+    "recommended_for": [
+      "education",
+      "cost_optimized",
+      "simple_control"
+    ],
+    "not_recommended_for": [
+      "pcie",
+      "linux",
+      "mipi_bridge"
+    ]
+  }
+]

--- a/lib/parser/selection-parser.js
+++ b/lib/parser/selection-parser.js
@@ -1,0 +1,177 @@
+/** @typedef {import('../../types/domain').SelectionRequest} SelectionRequest */
+/** @typedef {import('../../types/domain').ParsedConstraints} ParsedConstraints */
+
+const DEFAULT_TEAM = {
+  fpga_experience: 'intermediate',
+  ddr_experience: false,
+  serdes_experience: false,
+  linux_experience: false,
+  preferred_toolchains: [],
+  preferred_vendors: []
+};
+
+const DEFAULT_BUSINESS = {
+  stage: 'prototype',
+  budget_sensitivity: 'medium',
+  prioritize_supply: false,
+  prioritize_longevity: false,
+  target_temp_grade: 'commercial'
+};
+
+const scenarioKeywords = [
+  { id: 'embedded_vision_bridge', words: ['mipi', 'camera', 'vision', 'bridge', '双摄', '摄像头'] },
+  { id: 'pcie_data_acquisition', words: ['pcie', 'gen3', '采集卡', 'data acquisition', 'capture'] },
+  { id: 'education_entry', words: ['教学', 'education', '高校', 'student', 'lab'] },
+  { id: 'linux_soc_gateway', words: ['linux', 'soc', 'gateway', '网关'] },
+  { id: 'industrial_control', words: ['industrial', 'motor', '控制', '工业', '电机'] },
+  { id: 'low_power_edge_ai', words: ['edge ai', 'low power', '低功耗', 'inference'] },
+  { id: 'high_speed_connectivity', words: ['serdes', 'high speed', '高速', 'connectivity'] }
+];
+
+const vendorKeywords = ['AMD', 'Intel', 'Altera', 'Lattice', 'Microchip', 'Efinix', 'Gowin'];
+const toolchainKeywords = ['Vivado', 'Vitis', 'PetaLinux', 'Quartus', 'Radiant', 'Diamond', 'Libero', 'Efinity', 'Gowin EDA'];
+
+function inferApplicationId(query) {
+  const normalized = query.toLowerCase();
+  for (const candidate of scenarioKeywords) {
+    if (candidate.words.some((word) => normalized.includes(word.toLowerCase()))) {
+      return candidate.id;
+    }
+  }
+  return 'cost_optimized_general';
+}
+
+function inferTags(query) {
+  const normalized = query.toLowerCase();
+  const tags = new Set();
+  if (normalized.includes('mipi') || normalized.includes('camera') || normalized.includes('vision') || normalized.includes('摄像头')) tags.add('mipi');
+  if (normalized.includes('pcie')) tags.add('pcie');
+  if (normalized.includes('ddr')) tags.add('ddr');
+  if (normalized.includes('linux') || normalized.includes('soc')) tags.add('linux');
+  if (normalized.includes('industrial') || normalized.includes('工业')) tags.add('industrial');
+  if (normalized.includes('low power') || normalized.includes('低功耗')) tags.add('low_power');
+  if (normalized.includes('budget') || normalized.includes('成本') || normalized.includes('预算')) tags.add('budget_sensitive');
+  if (normalized.includes('教学') || normalized.includes('education')) tags.add('education');
+  if (normalized.includes('board') || normalized.includes('开发板')) tags.add('board_friendly');
+  return [...tags];
+}
+
+function extractNumericRequirement(query, expression) {
+  const matched = query.match(expression);
+  if (!matched) return undefined;
+  return Number(matched[1]);
+}
+
+function extractSignals(query) {
+  const lower = query.toLowerCase();
+  const vendorMatches = vendorKeywords.filter((item) => lower.includes(item.toLowerCase()));
+  const toolMatches = toolchainKeywords.filter((item) => lower.includes(item.toLowerCase()));
+  const cameraCount = extractNumericRequirement(lower, /(\d+)\s*(camera|cam|摄像头|路)/i) || (lower.includes('双摄') ? 2 : undefined);
+  const pcieGen = extractNumericRequirement(lower, /pcie\s*gen\s*(\d)/i) || extractNumericRequirement(lower, /gen\s*(\d)\s*pcie/i);
+  const ddrGen = extractNumericRequirement(lower, /ddr\s*(\d)/i);
+  const skillWarnings = [];
+  if (lower.includes('不会ddr') || lower.includes('no ddr experience')) skillWarnings.push('团队明确表示缺少 DDR 经验');
+  if (lower.includes('不会serdes') || lower.includes('no serdes experience')) skillWarnings.push('团队明确表示缺少 SerDes 经验');
+  const requirementSummary = [];
+  if (cameraCount) requirementSummary.push(`摄像头数量约 ${cameraCount} 路`);
+  if (pcieGen) requirementSummary.push(`需要至少 PCIe Gen${pcieGen}`);
+  if (ddrGen) requirementSummary.push(`偏好 DDR${ddrGen}`);
+  if (lower.includes('industrial') || lower.includes('工业')) requirementSummary.push('目标为工业级温度');
+  if (lower.includes('量产') || lower.includes('production')) requirementSummary.push('量产阶段要求更强生命周期与供货');
+  return {
+    camera_count: cameraCount,
+    required_pcie_gen: pcieGen,
+    required_ddr_gen: ddrGen,
+    toolchain_keywords: toolMatches,
+    vendor_keywords: vendorMatches,
+    skill_warnings: skillWarnings,
+    requirement_summary: requirementSummary
+  };
+}
+
+function inferTeamProfile(query, requestTeam) {
+  const lower = query.toLowerCase();
+  const profile = {
+    ...DEFAULT_TEAM,
+    ...requestTeam,
+    preferred_toolchains: requestTeam?.preferred_toolchains || [],
+    preferred_vendors: requestTeam?.preferred_vendors || []
+  };
+  if (lower.includes('教学') || lower.includes('student')) {
+    profile.fpga_experience = requestTeam?.fpga_experience || 'beginner';
+  }
+  if (lower.includes('linux')) profile.linux_experience = requestTeam?.linux_experience ?? true;
+  if (lower.includes('不会ddr') || lower.includes('no ddr experience')) profile.ddr_experience = false;
+  if (lower.includes('不会serdes') || lower.includes('no serdes experience')) profile.serdes_experience = false;
+  return profile;
+}
+
+function inferBusinessContext(query, requestBusiness) {
+  const lower = query.toLowerCase();
+  const business = { ...DEFAULT_BUSINESS, ...requestBusiness };
+  if (lower.includes('industrial') || query.includes('工业')) business.target_temp_grade = 'industrial';
+  if (lower.includes('budget') || query.includes('预算') || query.includes('低成本')) business.budget_sensitivity = 'high';
+  if (lower.includes('长期供货') || lower.includes('long life') || lower.includes('long supply')) {
+    business.prioritize_longevity = true;
+    business.prioritize_supply = true;
+  }
+  if (lower.includes('production') || query.includes('量产')) {
+    business.stage = 'production';
+    business.prioritize_longevity = true;
+    business.prioritize_supply = true;
+  }
+  if (lower.includes('prototype') || query.includes('原型')) business.stage = 'prototype';
+  return business;
+}
+
+/** @param {SelectionRequest} request @returns {ParsedConstraints} */
+export function parseSelectionRequest(request) {
+  const query = request.query || '';
+  const applicationId = request.applicationId || inferApplicationId(query);
+  const inferredTags = inferTags(query);
+  const extractedSignals = extractSignals(query);
+  const teamProfile = inferTeamProfile(query, request.team);
+  const businessContext = inferBusinessContext(query, request.business);
+
+  const preferredVendor = request.constraints?.vendor || extractedSignals.vendor_keywords[0] || teamProfile.preferred_vendors?.[0] || '';
+
+  const hardConstraints = {
+    min_logic_cells: request.constraints?.min_logic_cells ?? 0,
+    min_luts: request.constraints?.min_luts ?? 0,
+    min_dsp_blocks: request.constraints?.min_dsp_blocks ?? (applicationId === 'low_power_edge_ai' ? 64 : 0),
+    min_bram_kb: request.constraints?.min_bram_kb ?? (applicationId === 'linux_soc_gateway' ? 2048 : 0),
+    min_lvds_pairs: request.constraints?.min_lvds_pairs ?? 0,
+    min_gpio_count: request.constraints?.min_gpio_count ?? (applicationId === 'industrial_control' ? 120 : 0),
+    require_pcie: request.constraints?.require_pcie ?? inferredTags.includes('pcie'),
+    require_ddr: request.constraints?.require_ddr ?? (inferredTags.includes('ddr') || inferredTags.includes('linux')),
+    require_mipi: request.constraints?.require_mipi ?? inferredTags.includes('mipi'),
+    require_hard_cpu: request.constraints?.require_hard_cpu ?? inferredTags.includes('linux'),
+    max_power_profile: request.constraints?.max_power_profile ?? (inferredTags.includes('low_power') ? 'low' : 'high'),
+    max_price_band: request.constraints?.max_price_band ?? (businessContext.budget_sensitivity === 'high' ? 'mid' : 'high'),
+    preferred_package: request.constraints?.preferred_package ?? '',
+    vendor: preferredVendor
+  };
+
+  if (applicationId === 'education_entry') {
+    hardConstraints.max_price_band = request.constraints?.max_price_band ?? 'mid';
+    hardConstraints.max_power_profile = request.constraints?.max_power_profile ?? 'medium';
+  }
+  if (applicationId === 'embedded_vision_bridge') {
+    hardConstraints.require_mipi = request.constraints?.require_mipi ?? true;
+    hardConstraints.max_power_profile = request.constraints?.max_power_profile ?? 'low';
+  }
+  if (applicationId === 'pcie_data_acquisition') {
+    hardConstraints.require_pcie = request.constraints?.require_pcie ?? true;
+    hardConstraints.require_ddr = request.constraints?.require_ddr ?? true;
+  }
+
+  return {
+    applicationId,
+    inferredTags,
+    hardConstraints,
+    teamProfile,
+    businessContext,
+    normalizedQuery: query.trim().toLowerCase(),
+    extractedSignals
+  };
+}

--- a/lib/rules/expert-rules.js
+++ b/lib/rules/expert-rules.js
@@ -1,0 +1,79 @@
+/** @typedef {import('../../types/domain').ApplicationProfile} ApplicationProfile */
+/** @typedef {import('../../types/domain').ParsedConstraints} ParsedConstraints */
+/** @typedef {import('../../types/domain').FPGADevice} FPGADevice */
+
+/** @param {ApplicationProfile} profile @param {ParsedConstraints} parsed */
+export function deriveWeights(profile, parsed) {
+  const weights = { ...profile.defaultWeights };
+  if (parsed.applicationId === 'education_entry') {
+    weights.BoardFeasibility += 0.06;
+    weights.CostFit += 0.05;
+    weights.InterfaceFit -= 0.05;
+    weights.ResourceFit -= 0.06;
+  }
+  if (parsed.businessContext.stage === 'prototype') {
+    weights.BoardFeasibility += 0.06;
+    weights.ToolchainFit += 0.03;
+    weights.SupplyLifecycleFit -= 0.05;
+  }
+  if (parsed.businessContext.stage === 'production') {
+    weights.SupplyLifecycleFit += 0.08;
+    weights.CostFit += 0.03;
+    weights.BoardFeasibility -= 0.04;
+  }
+  if (parsed.applicationId === 'linux_soc_gateway') {
+    weights.ApplicationFit += 0.04;
+    weights.InterfaceFit += 0.03;
+  }
+  if (parsed.applicationId === 'embedded_vision_bridge') {
+    weights.InterfaceFit += 0.05;
+    weights.CostFit += 0.02;
+  }
+  if (parsed.teamProfile.fpga_experience === 'beginner') {
+    weights.BoardFeasibility += 0.05;
+    weights.ToolchainFit += 0.03;
+    weights.ResourceFit -= 0.04;
+  }
+  const total = Object.values(weights).reduce((sum, value) => sum + value, 0);
+  return Object.fromEntries(Object.entries(weights).map(([key, value]) => [key, value / total]));
+}
+
+/** @param {FPGADevice} device @param {ParsedConstraints} parsed */
+export function deviceRuleNotes(device, parsed) {
+  const notes = [];
+  let penalty = 0;
+
+  if (!parsed.teamProfile.ddr_experience && device.ddr_support.length > 0 && parsed.hardConstraints.require_ddr) {
+    penalty += device.board_complexity === 'high' ? 0.08 : 0.04;
+    notes.push('团队 DDR 经验有限，相关板级调试风险上升');
+  }
+  if (!parsed.teamProfile.serdes_experience && device.transceiver_channels > 0 && parsed.hardConstraints.require_pcie) {
+    penalty += device.board_complexity === 'high' ? 0.1 : 0.05;
+    notes.push('团队 SerDes 经验有限，高速链路 bring-up 难度较高');
+  }
+  if (parsed.applicationId === 'linux_soc_gateway' && device.hard_cpu) {
+    penalty -= 0.06;
+    notes.push('Linux/SoC 场景对硬核 CPU 有加权优势');
+  }
+  if (parsed.applicationId === 'embedded_vision_bridge' && device.mipi_support && ['ultra_low', 'low'].includes(device.power_profile)) {
+    penalty -= 0.06;
+    notes.push('视觉桥接场景偏好低功耗 MIPI 友好器件');
+  }
+  if (parsed.businessContext.stage === 'production' && device.lifecycle_status === 'new') {
+    penalty += 0.05;
+    notes.push('量产阶段对新器件生命周期稳定性更敏感');
+  }
+  if (parsed.businessContext.stage === 'production' && device.availability_score >= 8) {
+    penalty -= 0.03;
+    notes.push('供货与生命周期更适合量产阶段');
+  }
+  if (parsed.teamProfile.preferred_toolchains?.length && parsed.teamProfile.preferred_toolchains.some((tool) => device.toolchain.includes(tool))) {
+    penalty -= 0.03;
+    notes.push('符合团队现有工具链资产');
+  }
+  if (parsed.teamProfile.preferred_vendors?.length && parsed.teamProfile.preferred_vendors.some((vendor) => device.vendor.includes(vendor))) {
+    penalty -= 0.02;
+    notes.push('匹配品牌偏好，可减少导入成本');
+  }
+  return { penalty, notes };
+}

--- a/lib/scoring/explain.js
+++ b/lib/scoring/explain.js
@@ -1,0 +1,79 @@
+import { boardsForDevice } from '../data/boards.js';
+
+/** @typedef {import('../../types/domain').FPGADevice} FPGADevice */
+
+function summarizeScore(score) {
+  return Object.entries(score.dimensions)
+    .sort((a, b) => b[1].weighted - a[1].weighted)
+    .slice(0, 3)
+    .map(([key]) => key);
+}
+
+function stageAdviceForDevice(device, parsed) {
+  const prototype = [
+    device.board_complexity === 'high' ? '原型阶段建议优先采购成熟 SOM/EVK，降低高速板级风险。' : '原型阶段可直接基于现成开发板快速验证主链路。',
+    `优先使用 ${device.toolchain[0]} 官方参考设计建立 bring-up 基线。`
+  ];
+  const production = [
+    device.lifecycle_status === 'new' ? '量产前请额外确认生命周期窗口与替代料方案。' : '量产阶段可提前冻结该器件及封装，建立二供与备料策略。',
+    device.ddr_support.length > 0 ? '量产设计应尽早冻结 DDR 拓扑、时钟与 SI/PI 约束。' : '量产设计应聚焦 IO 保护、电源完整性与 EMC 验证。'
+  ];
+  if (parsed.businessContext.prioritize_supply) production.push('建议同步复核供货周期、代理渠道与生命周期公告。');
+  return { prototype, production };
+}
+
+function pickAlternative(ranked, currentId, predicate) {
+  return ranked.find((candidate) => candidate.device.id !== currentId && predicate(candidate.device))?.device;
+}
+
+/** @param {{device: FPGADevice, score: import('../../types/domain').ScoreBreakdown}[]} ranked */
+export function buildSelectionResults(ranked, parsed, topN) {
+  return ranked.slice(0, topN).map((entry, index) => {
+    const next = ranked[index + 1];
+    const cheaperAlternative = pickAlternative(ranked, entry.device.id, (device) => device.price_band === 'low');
+    const productionAlternative = pickAlternative(ranked, entry.device.id, (device) => device.lifecycle_status === 'active' && device.availability_score >= 8);
+    const dominant = summarizeScore(entry.score);
+    const risks = [];
+    if (entry.device.board_complexity === 'high') risks.push('板级设计与调试复杂度较高，建议保留 SI/PI 验证预算');
+    if (entry.device.price_band === 'high') risks.push('器件成本较高，需关注原型和量产 BOM 压力');
+    if (entry.device.lifecycle_status === 'new') risks.push('器件较新，量产前需复核长期供货稳定性');
+    if (parsed.teamProfile.fpga_experience === 'beginner' && entry.device.board_complexity !== 'low') risks.push('团队经验偏初级时，学习曲线可能偏陡');
+    if (!parsed.teamProfile.ddr_experience && parsed.hardConstraints.require_ddr) risks.push('当前团队 DDR 经验不足，建议优先选择参考设计成熟的平台');
+
+    const reasons = [
+      `综合得分 ${(entry.score.total * 100).toFixed(1)}，核心优势集中在 ${dominant.join(' / ')}。`,
+      ...dominant.flatMap((key) => entry.score.dimensions[key].notes.slice(0, 2))
+    ];
+
+    const advantages = [
+      `器件族：${entry.device.vendor} ${entry.device.family}。`,
+      `资源：${entry.device.logic_cells.toLocaleString()} logic cells，${entry.device.dsp_blocks} DSP，${entry.device.bram_kb} KB BRAM。`,
+      `接口：PCIe ${entry.device.pcie_support || '无'}；DDR ${entry.device.ddr_support.join('/') || '无'}；MIPI ${entry.device.mipi_support ? '支持' : '不支持'}。`,
+      `工具链：${entry.device.toolchain.join(' / ')}。`
+    ];
+
+    let whyBetterThanNext = '当前器件在综合场景适配和工程落地风险之间更均衡。';
+    if (next) {
+      whyBetterThanNext = `它比第二名 ${next.device.part_number} 更优，主要因为总分高 ${(entry.score.total - next.score.total).toFixed(2)}，并在 ${dominant[0]} 上表现更强。`;
+    }
+
+    return {
+      rank: index + 1,
+      device: entry.device,
+      score: entry.score,
+      reasons,
+      advantages,
+      risks: risks.length > 0 ? risks : ['无明显致命风险，但仍应在样机阶段验证接口与供电裕量。'],
+      whyBetterThanNext,
+      cheaperAlternative,
+      productionAlternative,
+      toolchainAdvice: [
+        `首选使用 ${entry.device.toolchain[0]} 建立参考设计。`,
+        parsed.businessContext.stage === 'prototype' ? '原型阶段优先复用官方或社区开发板示例。' : '量产阶段应尽早冻结器件封装、DDR 拓扑与时钟树。'
+      ],
+      boardRecommendations: boardsForDevice(entry.device.id),
+      stageAdvice: stageAdviceForDevice(entry.device, parsed),
+      fitSummary: `该器件更偏向 ${parsed.businessContext.stage === 'prototype' ? '快速原型验证' : '稳健量产导入'}，并在 ${dominant[0]} 上形成主要竞争力。`
+    };
+  });
+}

--- a/lib/scoring/filter.js
+++ b/lib/scoring/filter.js
@@ -1,0 +1,45 @@
+/** @typedef {import('../../types/domain').FPGADevice} FPGADevice */
+/** @typedef {import('../../types/domain').ParsedConstraints} ParsedConstraints */
+
+const powerRank = { ultra_low: 0, low: 1, medium: 2, high: 3 };
+const priceRank = { low: 0, mid: 1, high: 2 };
+
+function extractPcieGeneration(value) {
+  const matched = value?.match(/Gen(\d)/i);
+  return matched ? Number(matched[1]) : 0;
+}
+
+function extractDdrGeneration(values) {
+  return Math.max(0, ...values.map((value) => {
+    const matched = value.match(/DDR(\d)/i);
+    return matched ? Number(matched[1]) : 0;
+  }));
+}
+
+/** @param {FPGADevice[]} deviceList @param {ParsedConstraints} parsed */
+export function filterDevices(deviceList, parsed) {
+  const c = parsed.hardConstraints;
+  const requiredPcieGen = parsed.extractedSignals.required_pcie_gen || 0;
+  const requiredDdrGen = parsed.extractedSignals.required_ddr_gen || 0;
+
+  return deviceList.filter((device) => {
+    if (device.logic_cells < c.min_logic_cells) return false;
+    if (device.luts < c.min_luts) return false;
+    if (device.dsp_blocks < c.min_dsp_blocks) return false;
+    if (device.bram_kb < c.min_bram_kb) return false;
+    if (device.lvds_pairs < c.min_lvds_pairs) return false;
+    if (device.gpio_count < c.min_gpio_count) return false;
+    if (c.require_pcie && !device.pcie_support) return false;
+    if (c.require_ddr && device.ddr_support.length === 0) return false;
+    if (c.require_mipi && !device.mipi_support) return false;
+    if (c.require_hard_cpu && !device.hard_cpu) return false;
+    if (powerRank[device.power_profile] > powerRank[c.max_power_profile]) return false;
+    if (priceRank[device.price_band] > priceRank[c.max_price_band]) return false;
+    if (c.preferred_package && !device.package_options.some((option) => option.includes(c.preferred_package))) return false;
+    if (c.vendor && !device.vendor.toLowerCase().includes(c.vendor.toLowerCase())) return false;
+    if (parsed.businessContext.target_temp_grade && !device.temp_grades.includes(parsed.businessContext.target_temp_grade)) return false;
+    if (requiredPcieGen && extractPcieGeneration(device.pcie_support) < requiredPcieGen) return false;
+    if (requiredDdrGen && extractDdrGeneration(device.ddr_support) < requiredDdrGen) return false;
+    return true;
+  });
+}

--- a/lib/scoring/rank.js
+++ b/lib/scoring/rank.js
@@ -1,0 +1,201 @@
+import { getApplicationProfile } from '../data/applications.js';
+import { boardsForDevice } from '../data/boards.js';
+import { deviceRuleNotes, deriveWeights } from '../rules/expert-rules.js';
+
+/** @typedef {import('../../types/domain').FPGADevice} FPGADevice */
+/** @typedef {import('../../types/domain').ParsedConstraints} ParsedConstraints */
+/** @typedef {import('../../types/domain').ScoreBreakdown} ScoreBreakdown */
+
+const priceRank = { low: 1, mid: 0.6, high: 0.2 };
+const lifecycleRank = { active: 0.9, mature: 0.8, new: 0.65, legacy: 0.3 };
+const complexityRank = { low: 1, medium: 0.7, high: 0.35 };
+const powerRank = { ultra_low: 1, low: 0.8, medium: 0.5, high: 0.2 };
+
+function normalizedRatio(actual, target) {
+  if (!target) return 1;
+  return Math.max(0, Math.min(1, actual / target));
+}
+
+function extractPcieGen(value) {
+  const matched = value?.match(/Gen(\d)/i);
+  return matched ? Number(matched[1]) : 0;
+}
+
+function extractDdrGen(values) {
+  return Math.max(0, ...values.map((value) => {
+    const matched = value.match(/DDR(\d)/i);
+    return matched ? Number(matched[1]) : 0;
+  }));
+}
+
+function interfaceScore(device, parsed) {
+  const notes = [];
+  let score = 0.45;
+  const requiredPcieGen = parsed.extractedSignals.required_pcie_gen || 0;
+  const requiredDdrGen = parsed.extractedSignals.required_ddr_gen || 0;
+
+  if (parsed.hardConstraints.require_pcie) {
+    const deviceGen = extractPcieGen(device.pcie_support);
+    score += device.pcie_support ? 0.2 : -0.3;
+    if (device.pcie_support) {
+      notes.push(`支持 ${device.pcie_support}`);
+      if (requiredPcieGen > 0 && deviceGen >= requiredPcieGen) score += 0.08;
+    }
+  }
+  if (parsed.hardConstraints.require_ddr) {
+    const deviceDdrGen = extractDdrGen(device.ddr_support);
+    score += device.ddr_support.length > 0 ? 0.14 : -0.2;
+    if (device.ddr_support.length > 0) {
+      notes.push(`支持 ${device.ddr_support.join('/')}`);
+      if (requiredDdrGen > 0 && deviceDdrGen >= requiredDdrGen) score += 0.08;
+    }
+  }
+  if (parsed.hardConstraints.require_mipi) {
+    score += device.mipi_support ? 0.22 : -0.25;
+    if (device.mipi_support) notes.push('支持 MIPI 友好接口');
+  }
+  if (parsed.hardConstraints.require_hard_cpu) {
+    score += device.hard_cpu ? 0.2 : -0.25;
+    if (device.hard_cpu) notes.push('具备硬核 CPU，适合 Linux/SoC');
+  }
+  if (parsed.applicationId === 'high_speed_connectivity' && device.transceiver_channels > 0) {
+    score += 0.08;
+    notes.push(`具备 ${device.transceiver_channels} 路高速收发器`);
+  }
+  return { raw: Math.max(0, Math.min(1, score)), notes };
+}
+
+function applicationScore(device, parsed, profile) {
+  let score = 0.5;
+  const notes = [];
+  for (const trait of profile.preferredTraits) {
+    if (device.recommended_for.some((value) => value.includes(trait) || trait.includes(value))) {
+      score += 0.08;
+      notes.push(`贴合 ${trait} 场景`);
+    }
+  }
+  for (const trait of profile.avoidedTraits) {
+    if (device.not_recommended_for.some((value) => value.includes(trait) || trait.includes(value))) {
+      score -= 0.06;
+    }
+  }
+  if (parsed.inferredTags.includes('industrial') && device.temp_grades.includes('industrial')) {
+    score += 0.08;
+    notes.push('提供工业级温度支持');
+  }
+  if (parsed.inferredTags.includes('budget_sensitive') && device.price_band === 'low') {
+    score += 0.1;
+    notes.push('更适合预算敏感项目');
+  }
+  if (parsed.extractedSignals.camera_count && device.mipi_support) {
+    score += 0.05;
+    notes.push(`适合 ${parsed.extractedSignals.camera_count} 路视觉输入类设计`);
+  }
+  return { raw: Math.max(0, Math.min(1, score)), notes };
+}
+
+function resourceScore(device, parsed) {
+  const c = parsed.hardConstraints;
+  const scores = [
+    normalizedRatio(device.logic_cells, c.min_logic_cells),
+    normalizedRatio(device.luts, c.min_luts),
+    normalizedRatio(device.dsp_blocks, c.min_dsp_blocks),
+    normalizedRatio(device.bram_kb, c.min_bram_kb),
+    normalizedRatio(device.lvds_pairs, c.min_lvds_pairs || 1),
+    normalizedRatio(device.gpio_count, c.min_gpio_count || 1)
+  ];
+  if (parsed.applicationId === 'pcie_data_acquisition' && device.transceiver_channels > 0) scores.push(Math.min(1, device.transceiver_channels / 8));
+  if (parsed.applicationId === 'low_power_edge_ai') scores.push(Math.min(1, device.dsp_blocks / 256));
+  return { raw: scores.reduce((sum, value) => sum + value, 0) / scores.length, notes: ['资源余量按需求下限归一化'] };
+}
+
+function toolchainScore(device, parsed) {
+  const preferred = [...(parsed.teamProfile.preferred_toolchains || []), ...parsed.extractedSignals.toolchain_keywords];
+  let raw = 0.6;
+  const notes = [];
+  if (preferred.length > 0) {
+    const matched = preferred.some((tool) => device.toolchain.some((candidate) => candidate.toLowerCase().includes(tool.toLowerCase())));
+    raw += matched ? 0.25 : -0.12;
+    notes.push(matched ? '符合团队工具链偏好' : '与团队工具链偏好有偏差');
+  }
+  if (device.toolchain.some((tool) => /open-source/i.test(tool))) {
+    raw += 0.05;
+    notes.push('具备开放生态加成');
+  }
+  return { raw: Math.max(0, Math.min(1, raw)), notes };
+}
+
+function boardScore(device, parsed) {
+  const boards = boardsForDevice(device.id);
+  let raw = ((device.board_maturity_score / 10) * 0.7) + (complexityRank[device.board_complexity] * 0.3);
+  const notes = [];
+  if (boards.length > 0) {
+    raw += 0.1;
+    notes.push(`${boards.length} 款已知开发板/模块可用`);
+  }
+  if (parsed.businessContext.stage === 'prototype') {
+    raw += 0.05;
+    notes.push('原型阶段受益于成熟开发板');
+  }
+  if (parsed.applicationId === 'education_entry' && device.board_complexity === 'low') {
+    raw += 0.05;
+    notes.push('适合教学场景快速上手');
+  }
+  return { raw: Math.max(0, Math.min(1, raw)), notes };
+}
+
+function costScore(device, parsed) {
+  let raw = priceRank[device.price_band];
+  if (parsed.businessContext.budget_sensitivity === 'high' && device.price_band === 'low') raw += 0.18;
+  if (parsed.businessContext.budget_sensitivity === 'low' && device.price_band === 'high') raw += 0.05;
+  if (parsed.businessContext.stage === 'prototype' && device.price_band !== 'high') raw += 0.05;
+  return { raw: Math.max(0, Math.min(1, raw)), notes: [`价格带 ${device.price_band}`] };
+}
+
+function supplyScore(device, parsed) {
+  let raw = (device.availability_score / 10) * 0.55 + lifecycleRank[device.lifecycle_status] * 0.45;
+  const notes = [`供货评分 ${device.availability_score}/10`, `生命周期 ${device.lifecycle_status}`];
+  if (parsed.businessContext.prioritize_supply && device.availability_score >= 8) raw += 0.08;
+  if (parsed.businessContext.prioritize_longevity && ['active', 'mature'].includes(device.lifecycle_status)) raw += 0.08;
+  return { raw: Math.max(0, Math.min(1, raw)), notes };
+}
+
+function communityScore(device, parsed) {
+  let raw = device.community_score / 10;
+  const notes = [`社区成熟度 ${device.community_score}/10`];
+  if (parsed.applicationId === 'education_entry' && device.community_score >= 8) raw += 0.08;
+  if (parsed.applicationId === 'linux_soc_gateway' && device.hard_cpu) raw += 0.05;
+  return { raw: Math.max(0, Math.min(1, raw)), notes };
+}
+
+/** @param {FPGADevice} device @param {ParsedConstraints} parsed @returns {ScoreBreakdown} */
+export function scoreDevice(device, parsed) {
+  const profile = getApplicationProfile(parsed.applicationId);
+  const weights = deriveWeights(profile, parsed);
+  const dimensions = {
+    ApplicationFit: applicationScore(device, parsed, profile),
+    ResourceFit: resourceScore(device, parsed),
+    InterfaceFit: interfaceScore(device, parsed),
+    ToolchainFit: toolchainScore(device, parsed),
+    BoardFeasibility: boardScore(device, parsed),
+    CostFit: costScore(device, parsed),
+    SupplyLifecycleFit: supplyScore(device, parsed),
+    CommunityFit: communityScore(device, parsed)
+  };
+  const rules = deviceRuleNotes(device, parsed);
+  const powerModifier = parsed.inferredTags.includes('low_power') ? powerRank[device.power_profile] * 0.03 : 0;
+  const totalBeforePenalty = Object.entries(dimensions).reduce((sum, [key, value]) => sum + (value.raw * weights[key]), 0) + powerModifier;
+  const total = Math.max(0, Math.min(1, totalBeforePenalty - rules.penalty));
+  const weightedDimensions = Object.fromEntries(
+    Object.entries(dimensions).map(([key, value]) => [key, { ...value, weighted: value.raw * weights[key] }])
+  );
+  if (rules.notes.length > 0) weightedDimensions.ApplicationFit.notes.push(...rules.notes);
+  return { total, weights, dimensions: weightedDimensions };
+}
+
+/** @param {FPGADevice[]} candidates @param {ParsedConstraints} parsed */
+export function rankDevices(candidates, parsed) {
+  return candidates
+    .map((device) => ({ device, score: scoreDevice(device, parsed) }))
+    .sort((a, b) => b.score.total - a.score.total);
+}

--- a/lib/selection-service.js
+++ b/lib/selection-service.js
@@ -1,0 +1,93 @@
+import { applicationProfiles, getApplicationProfile } from './data/applications.js';
+import { devices, getDeviceById } from './data/devices.js';
+import { boardsForDevice } from './data/boards.js';
+import { parseSelectionRequest } from './parser/selection-parser.js';
+import { filterDevices } from './scoring/filter.js';
+import { rankDevices } from './scoring/rank.js';
+import { buildSelectionResults } from './scoring/explain.js';
+
+function cloneRequestWithStage(request, stage) {
+  return {
+    ...request,
+    business: {
+      ...(request.business || {}),
+      stage,
+      prioritize_longevity: stage === 'production' ? true : request.business?.prioritize_longevity,
+      prioritize_supply: stage === 'production' ? true : request.business?.prioritize_supply
+    }
+  };
+}
+
+function recommendCore(request) {
+  const parsed = parseSelectionRequest(request);
+  const filtered = filterDevices(devices, parsed);
+  const ranked = rankDevices(filtered, parsed);
+  const results = buildSelectionResults(ranked, parsed, request.topN || 3);
+  return { parsed, filtered, ranked, results };
+}
+
+function buildStageComparison(request) {
+  const prototype = recommendCore(cloneRequestWithStage(request, 'prototype'));
+  const production = recommendCore(cloneRequestWithStage(request, 'production'));
+  const summary = [];
+  if (prototype.results[0]) summary.push(`原型优先器件：${prototype.results[0].device.part_number}，更看重开发板成熟度与 bring-up 速度。`);
+  if (production.results[0]) summary.push(`量产优先器件：${production.results[0].device.part_number}，更看重生命周期、供货与长期可维护性。`);
+  if (prototype.results[0] && production.results[0] && prototype.results[0].device.id === production.results[0].device.id) {
+    summary.push('原型与量产阶段的首选器件一致，说明该需求下技术与供应约束较为统一。');
+  }
+  return {
+    prototypeTop: prototype.results[0]?.device,
+    productionTop: production.results[0]?.device,
+    summary
+  };
+}
+
+export function parseOnly(request) {
+  return parseSelectionRequest(request);
+}
+
+export function searchDevices(request) {
+  const parsed = parseSelectionRequest(request);
+  const filtered = filterDevices(devices, parsed);
+  return {
+    parsed,
+    totalCandidates: filtered.length,
+    applicationProfile: getApplicationProfile(parsed.applicationId),
+    devices: filtered
+  };
+}
+
+export function rankSelection(request) {
+  const parsed = parseSelectionRequest(request);
+  const filtered = filterDevices(devices, parsed);
+  const ranked = rankDevices(filtered, parsed);
+  return { parsed, totalCandidates: filtered.length, ranked };
+}
+
+export function recommendSelection(request) {
+  const core = recommendCore(request);
+  const warnings = [...core.parsed.extractedSignals.skill_warnings];
+  if (core.filtered.length === 0) warnings.push('没有器件满足当前硬约束，请放宽价格带、功耗等级或接口要求。');
+  if (core.filtered.length > 0 && core.filtered.length < 3) warnings.push('满足硬约束的候选器件较少，建议补充替代路线验证。');
+  return {
+    parsed: core.parsed,
+    totalCandidates: core.filtered.length,
+    warnings,
+    stageComparison: buildStageComparison(request),
+    results: core.results
+  };
+}
+
+export function listDevices() {
+  return devices;
+}
+
+export function getDeviceDetails(id) {
+  const device = getDeviceById(id);
+  if (!device) return null;
+  return { ...device, boards: boardsForDevice(id) };
+}
+
+export function listApplicationProfiles() {
+  return applicationProfiles;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "fpga-selection-agent-mvp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node server.mjs",
+    "start": "node server.mjs",
+    "build": "node --check server.mjs && node --check $(find app components lib -name '*.js' -print)",
+    "typecheck": "tsc --project tsconfig.json",
+    "test": "node --test tests/*.test.mjs",
+    "smoke": "bash scripts/smoke-test.sh",
+    "run": "bash scripts/run-agent.sh"
+  }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,193 @@
+const demos = [
+  '低功耗 MIPI 双摄桥接模块，工业级，预算敏感',
+  '需要 PCIe Gen3 和 DDR4 的数据采集卡',
+  '用于高校教学的低成本 FPGA 开发板选型',
+  'Linux 边缘网关，偏向 SoC FPGA',
+  '工业电机控制，要求低功耗和长期供货'
+];
+
+const form = document.querySelector('#selection-form');
+const statusEl = document.querySelector('#status');
+const parsedPanel = document.querySelector('#parsed-panel');
+const comparisonPanel = document.querySelector('#comparison-panel');
+const resultsPanel = document.querySelector('#results-panel');
+
+function pickDemo(index = 0) {
+  const query = document.querySelector('#query');
+  query.value = demos[index];
+}
+
+function formDataToPayload() {
+  const value = (id) => document.querySelector(`#${id}`)?.value;
+  const checked = (id) => document.querySelector(`#${id}`)?.checked;
+  return {
+    query: value('query'),
+    applicationId: value('applicationId') || undefined,
+    topN: Number(value('topN') || 3),
+    constraints: {
+      min_luts: Number(value('min_luts') || 0),
+      min_dsp_blocks: Number(value('min_dsp_blocks') || 0),
+      min_bram_kb: Number(value('min_bram_kb') || 0),
+      min_gpio_count: Number(value('min_gpio_count') || 0),
+      max_price_band: value('max_price_band'),
+      max_power_profile: value('max_power_profile'),
+      require_mipi: checked('require_mipi'),
+      require_pcie: checked('require_pcie'),
+      require_ddr: checked('require_ddr'),
+      require_hard_cpu: checked('require_hard_cpu')
+    },
+    team: {
+      fpga_experience: value('fpga_experience'),
+      ddr_experience: checked('ddr_experience'),
+      serdes_experience: checked('serdes_experience'),
+      linux_experience: checked('linux_experience')
+    },
+    business: {
+      stage: value('stage'),
+      budget_sensitivity: value('budget_sensitivity'),
+      prioritize_supply: checked('prioritize_supply'),
+      prioritize_longevity: checked('prioritize_longevity'),
+      target_temp_grade: value('target_temp_grade')
+    }
+  };
+}
+
+function renderParsed(parsed, count, warnings) {
+  parsedPanel.classList.remove('hidden');
+  const summary = parsed.extractedSignals.requirement_summary?.length
+    ? parsed.extractedSignals.requirement_summary.map((item) => `<li>${item}</li>`).join('')
+    : '<li>未从自然语言中提取到额外强约束。</li>';
+  const warningHtml = warnings?.length
+    ? `<div class="warning-box"><strong>风险提醒</strong><ul>${warnings.map((item) => `<li>${item}</li>`).join('')}</ul></div>`
+    : '';
+  parsedPanel.innerHTML = `
+    <h2>需求解析</h2>
+    <div class="summary-grid">
+      <div class="summary-card"><strong>Application</strong><div>${parsed.applicationId}</div></div>
+      <div class="summary-card"><strong>Tags</strong><div>${parsed.inferredTags.join(', ') || 'none'}</div></div>
+      <div class="summary-card"><strong>Stage</strong><div>${parsed.businessContext.stage}</div></div>
+      <div class="summary-card"><strong>Candidates</strong><div>${count}</div></div>
+    </div>
+    <div class="list-grid">
+      <section class="list-card"><h4>自动提取约束</h4><ul>${summary}</ul></section>
+      <section class="list-card"><h4>团队画像</h4><ul><li>FPGA 经验：${parsed.teamProfile.fpga_experience}</li><li>DDR：${parsed.teamProfile.ddr_experience ? '有经验' : '经验不足'}</li><li>SerDes：${parsed.teamProfile.serdes_experience ? '有经验' : '经验不足'}</li><li>Linux：${parsed.teamProfile.linux_experience ? '有经验' : '经验不足'}</li></ul></section>
+      <section class="list-card"><h4>业务上下文</h4><ul><li>阶段：${parsed.businessContext.stage}</li><li>预算：${parsed.businessContext.budget_sensitivity}</li><li>供货优先：${parsed.businessContext.prioritize_supply ? '是' : '否'}</li><li>寿命优先：${parsed.businessContext.prioritize_longevity ? '是' : '否'}</li></ul></section>
+    </div>
+    ${warningHtml}
+  `;
+}
+
+function renderStageComparison(stageComparison) {
+  comparisonPanel.classList.remove('hidden');
+  comparisonPanel.innerHTML = `
+    <h2>原型阶段 vs 量产阶段</h2>
+    <div class="compare-grid">
+      <div class="list-card">
+        <h4>Prototype 首选</h4>
+        <p><strong>${stageComparison.prototypeTop?.part_number || '暂无'}</strong></p>
+        <p class="muted">${stageComparison.prototypeTop ? `${stageComparison.prototypeTop.vendor} / ${stageComparison.prototypeTop.family}` : '无满足条件器件'}</p>
+      </div>
+      <div class="list-card">
+        <h4>Production 首选</h4>
+        <p><strong>${stageComparison.productionTop?.part_number || '暂无'}</strong></p>
+        <p class="muted">${stageComparison.productionTop ? `${stageComparison.productionTop.vendor} / ${stageComparison.productionTop.family}` : '无满足条件器件'}</p>
+      </div>
+    </div>
+    <div class="list-card"><h4>差异化建议</h4><ul>${(stageComparison.summary || []).map((item) => `<li>${item}</li>`).join('')}</ul></div>
+  `;
+}
+
+function dimensionRows(score) {
+  return Object.entries(score.dimensions).map(([key, value]) => `
+    <div class="dimension-row">
+      <span>${key}</span>
+      <div class="dimension-bar"><div class="dimension-fill" style="width:${(value.raw * 100).toFixed(0)}%"></div></div>
+      <strong>${(value.raw * 100).toFixed(0)}</strong>
+    </div>
+  `).join('');
+}
+
+function renderResults(results) {
+  resultsPanel.classList.remove('hidden');
+  if (!results.length) {
+    resultsPanel.innerHTML = '<h2>推荐结果</h2><p class="warning">没有器件满足当前硬约束，请放宽 LUT / 价格带 / 功耗等级等条件。</p>';
+    return;
+  }
+
+  const cards = results.map((result) => `
+    <article class="result-card">
+      <div class="result-head">
+        <div>
+          <h3>#${result.rank} · ${result.device.part_number}</h3>
+          <div class="muted">${result.device.vendor} / ${result.device.family} / ${result.device.device_type}</div>
+          <div>
+            <span class="tag">${result.device.price_band}</span>
+            <span class="tag">${result.device.power_profile}</span>
+            <span class="tag">${result.device.lifecycle_status}</span>
+          </div>
+          <p class="success">${result.fitSummary}</p>
+        </div>
+        <div class="score-pill">Score ${(result.score.total * 100).toFixed(1)}</div>
+      </div>
+      <div class="list-grid">
+        <section class="list-card"><h4>为什么推荐</h4><ul>${result.reasons.map((item) => `<li>${item}</li>`).join('')}</ul></section>
+        <section class="list-card"><h4>主要优势</h4><ul>${result.advantages.map((item) => `<li>${item}</li>`).join('')}</ul></section>
+        <section class="list-card"><h4>主要风险</h4><ul>${result.risks.map((item) => `<li class="risk">${item}</li>`).join('')}</ul></section>
+        <section class="list-card"><h4>工具链建议</h4><ul>${result.toolchainAdvice.map((item) => `<li>${item}</li>`).join('')}</ul></section>
+      </div>
+      <div class="list-grid">
+        <section class="list-card"><h4>优于第二名的原因</h4><p>${result.whyBetterThanNext}</p></section>
+        <section class="list-card"><h4>替代器件</h4><p>更便宜：${result.cheaperAlternative ? result.cheaperAlternative.part_number : '无'}</p><p>更适合量产：${result.productionAlternative ? result.productionAlternative.part_number : '无'}</p></section>
+        <section class="list-card"><h4>开发板建议</h4>${result.boardRecommendations.length ? `<ul>${result.boardRecommendations.map((board) => `<li><strong>${board.name}</strong> · ${board.summary}</li>`).join('')}</ul>` : '<p class="warning">暂无内置开发板，请优先评估官方 EVK 或第三方 SOM。</p>'}</section>
+      </div>
+      <div class="list-grid">
+        <section class="list-card"><h4>阶段建议</h4><p><strong>Prototype</strong></p><ul>${result.stageAdvice.prototype.map((item) => `<li>${item}</li>`).join('')}</ul><p><strong>Production</strong></p><ul>${result.stageAdvice.production.map((item) => `<li>${item}</li>`).join('')}</ul></section>
+        <section class="list-card"><h4>评分拆解</h4><div class="dimension-grid">${dimensionRows(result.score)}</div></section>
+      </div>
+    </article>
+  `).join('');
+
+  const compareRows = results.map((result) => `
+    <tr>
+      <td>${result.rank}</td>
+      <td>${result.device.part_number}</td>
+      <td>${result.device.logic_cells}</td>
+      <td>${result.device.dsp_blocks}</td>
+      <td>${result.device.pcie_support || 'No'}</td>
+      <td>${result.device.ddr_support.join(', ') || 'No'}</td>
+      <td>${result.device.mipi_support ? 'Yes' : 'No'}</td>
+      <td>${result.device.toolchain.join(' / ')}</td>
+      <td>${(result.score.total * 100).toFixed(1)}</td>
+    </tr>`).join('');
+
+  resultsPanel.innerHTML = `<h2>推荐结果</h2>${cards}<h2>候选器件对比</h2><table><thead><tr><th>Rank</th><th>Part</th><th>Logic Cells</th><th>DSP</th><th>PCIe</th><th>DDR</th><th>MIPI</th><th>Toolchain</th><th>Score</th></tr></thead><tbody>${compareRows}</tbody></table>`;
+}
+
+async function submit() {
+  statusEl.textContent = '正在解析需求并生成推荐...';
+  const payload = formDataToPayload();
+  const response = await fetch('/api/selection/recommend', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  const data = await response.json();
+  renderParsed(data.parsed, data.totalCandidates, data.warnings);
+  renderStageComparison(data.stageComparison);
+  renderResults(data.results);
+  statusEl.textContent = `已完成推荐，候选器件 ${data.totalCandidates} 个。`;
+}
+
+form?.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  try {
+    await submit();
+  } catch (error) {
+    console.error(error);
+    statusEl.textContent = '生成推荐失败，请检查输入或查看终端日志。';
+  }
+});
+
+document.querySelector('#load-demo')?.addEventListener('click', () => pickDemo(0));
+document.querySelectorAll('[data-demo-index]').forEach((button) => button.addEventListener('click', () => pickDemo(Number(button.dataset.demoIndex || '0'))));
+pickDemo(0);

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,63 @@
+:root {
+  --bg: #08111f;
+  --panel: rgba(10, 23, 43, 0.85);
+  --panel-border: rgba(122, 162, 255, 0.16);
+  --accent: #5eead4;
+  --accent-2: #60a5fa;
+  --text: #e5eefc;
+  --muted: #96a7c3;
+  --danger: #fda4af;
+  --warning: #fdba74;
+  --success: #86efac;
+}
+* { box-sizing: border-box; }
+body { margin: 0; font-family: Inter, ui-sans-serif, system-ui, sans-serif; background: radial-gradient(circle at top, #0f1f3b, var(--bg) 60%); color: var(--text); }
+.page-shell { max-width: 1360px; margin: 0 auto; padding: 32px 20px 80px; }
+.hero { display: grid; grid-template-columns: 2fr 1fr; gap: 20px; margin-bottom: 24px; }
+.hero h1 { font-size: clamp(2rem, 4vw, 3.6rem); margin: 0; }
+.hero-copy { max-width: 720px; color: var(--muted); font-size: 1.05rem; }
+.eyebrow { color: var(--accent); text-transform: uppercase; letter-spacing: 0.16em; font-size: 0.8rem; }
+.hero-card, .panel, .status { background: var(--panel); border: 1px solid var(--panel-border); border-radius: 20px; backdrop-filter: blur(14px); box-shadow: 0 10px 30px rgba(0,0,0,0.2); }
+.hero-card, .panel { padding: 20px; }
+.grid { display: grid; gap: 20px; }
+.two-col { grid-template-columns: minmax(0, 1.4fr) minmax(320px, 0.8fr); }
+.form-grid { grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
+label { display: flex; flex-direction: column; gap: 8px; font-size: 0.92rem; color: var(--muted); }
+input, select, textarea, button { font: inherit; }
+input, select, textarea { width: 100%; padding: 12px 14px; border-radius: 14px; border: 1px solid rgba(148, 163, 184, 0.18); background: rgba(15, 23, 42, 0.95); color: var(--text); }
+textarea { resize: vertical; min-height: 120px; }
+.check-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 10px; color: var(--text); }
+.check-grid label { flex-direction: row; align-items: center; gap: 10px; padding: 10px 12px; border: 1px solid rgba(148, 163, 184, 0.14); border-radius: 14px; }
+button { border: 0; border-radius: 14px; padding: 12px 18px; cursor: pointer; }
+.actions { display: flex; gap: 12px; }
+.actions button:first-child, .demo-item { background: linear-gradient(135deg, var(--accent-2), var(--accent)); color: #06111f; font-weight: 700; }
+.actions button:last-child { background: rgba(255,255,255,0.08); color: var(--text); }
+.demo-list { display: flex; flex-direction: column; gap: 12px; }
+.demo-item { text-align: left; }
+.stack-sm > * + * { margin-top: 10px; }
+.stack-lg > * + * { margin-top: 18px; }
+.status { padding: 14px 20px; margin: 20px 0; color: var(--muted); }
+.hidden { display: none; }
+.summary-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; margin-top: 12px; }
+.summary-card { border: 1px solid rgba(148,163,184,0.14); border-radius: 16px; padding: 14px; background: rgba(15,23,42,0.6); }
+.result-card { border: 1px solid rgba(148,163,184,0.14); border-radius: 18px; padding: 18px; background: rgba(15,23,42,0.6); margin-top: 18px; }
+.result-head { display: flex; justify-content: space-between; gap: 16px; align-items: flex-start; flex-wrap: wrap; }
+.score-pill { padding: 10px 14px; border-radius: 999px; background: rgba(94,234,212,0.16); color: var(--accent); font-weight: 700; }
+.tag { display: inline-flex; padding: 5px 10px; border-radius: 999px; background: rgba(96,165,250,0.16); color: #bfdbfe; margin: 6px 8px 0 0; font-size: 0.85rem; }
+.list-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 14px; margin-top: 14px; }
+.list-card { border-radius: 16px; padding: 14px; background: rgba(8,17,31,0.7); border: 1px solid rgba(148,163,184,0.12); }
+.list-card h4 { margin-top: 0; }
+.risk { color: var(--danger); }
+.warning { color: var(--warning); }
+.success { color: var(--success); }
+.compare-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; }
+.dimension-grid { display: grid; gap: 10px; }
+.dimension-row { display: grid; grid-template-columns: 120px 1fr 54px; gap: 10px; align-items: center; }
+.dimension-bar { height: 10px; background: rgba(148,163,184,0.14); border-radius: 999px; overflow: hidden; }
+.dimension-fill { height: 100%; background: linear-gradient(135deg, var(--accent-2), var(--accent)); }
+table { width: 100%; border-collapse: collapse; margin-top: 22px; }
+th, td { text-align: left; padding: 12px 10px; border-bottom: 1px solid rgba(148,163,184,0.14); vertical-align: top; }
+th { color: #bfdbfe; font-weight: 700; }
+.muted-list, .muted { color: var(--muted); }
+.warning-box { border-left: 3px solid var(--warning); padding-left: 12px; color: var(--warning); }
+@media (max-width: 960px) { .hero, .two-col { grid-template-columns: 1fr; } }

--- a/scripts/run-agent.sh
+++ b/scripts/run-agent.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[FPGA Selection Agent] 启动中..."
+echo "- 项目目录: $ROOT_DIR"
+echo "- 访问地址: http://localhost:3000"
+echo "- 停止服务: Ctrl+C"
+
+echo
+node server.mjs

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost:3000}"
+
+echo "[Smoke Test] GET $BASE_URL/api/devices"
+curl -s "$BASE_URL/api/devices" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const j=JSON.parse(s); if(!Array.isArray(j)||j.length===0) process.exit(1); console.log('devices:', j.length, 'first:', j[0].part_number);})"
+
+echo "[Smoke Test] POST $BASE_URL/api/selection/recommend"
+curl -s -X POST "$BASE_URL/api/selection/recommend" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"低功耗 MIPI 双摄桥接模块，工业级，预算敏感","topN":2}' \
+  | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const j=JSON.parse(s); if(!j.results||!j.results.length) process.exit(1); console.log('top1:', j.results[0].device.part_number, 'application:', j.parsed.applicationId);})"
+
+echo "[Smoke Test] PASS"

--- a/server.mjs
+++ b/server.mjs
@@ -1,0 +1,99 @@
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname, join } from 'node:path';
+import { renderIndexPage } from './app/page.js';
+import { handleParse } from './app/api/selection/parse/route.js';
+import { handleSearch } from './app/api/selection/search/route.js';
+import { handleRank } from './app/api/selection/rank/route.js';
+import { handleRecommend } from './app/api/selection/recommend/route.js';
+import { handleDevices } from './app/api/devices/route.js';
+import { handleDeviceById } from './app/api/devices/[id]/route.js';
+
+const PORT = Number(process.env.PORT || 3000);
+
+function json(res, status, payload) {
+  res.writeHead(status, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(payload, null, 2));
+}
+
+async function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = '';
+    req.on('data', (chunk) => { raw += chunk; });
+    req.on('end', () => {
+      try { resolve(raw ? JSON.parse(raw) : {}); } catch (error) { reject(error); }
+    });
+    req.on('error', reject);
+  });
+}
+
+async function serveStatic(pathname, res) {
+  const filePath = join(process.cwd(), 'public', pathname.replace(/^\//, ''));
+  const data = await readFile(filePath);
+  const contentType = extname(filePath) === '.css' ? 'text/css' : 'application/javascript';
+  res.writeHead(200, { 'Content-Type': `${contentType}; charset=utf-8` });
+  res.end(data);
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url || '/', `http://${req.headers.host}`);
+    const { pathname } = url;
+
+    if (pathname === '/') {
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(renderIndexPage());
+      return;
+    }
+    if (pathname === '/styles.css' || pathname === '/app.js') {
+      await serveStatic(pathname, res);
+      return;
+    }
+    if (pathname === '/api/devices' && req.method === 'GET') {
+      json(res, 200, handleDevices());
+      return;
+    }
+    if (pathname.startsWith('/api/devices/') && req.method === 'GET') {
+      const id = pathname.split('/').pop();
+      const device = handleDeviceById(id || '');
+      if (!device) {
+        json(res, 404, { message: 'Device not found' });
+        return;
+      }
+      json(res, 200, device);
+      return;
+    }
+    if (pathname === '/api/selection/parse' && req.method === 'POST') {
+      json(res, 200, handleParse(await parseBody(req)));
+      return;
+    }
+    if (pathname === '/api/selection/search' && req.method === 'POST') {
+      json(res, 200, handleSearch(await parseBody(req)));
+      return;
+    }
+    if (pathname === '/api/selection/rank' && req.method === 'POST') {
+      json(res, 200, handleRank(await parseBody(req)));
+      return;
+    }
+    if (pathname === '/api/selection/recommend' && req.method === 'POST') {
+      json(res, 200, handleRecommend(await parseBody(req)));
+      return;
+    }
+    json(res, 404, { message: 'Not found' });
+  } catch (error) {
+    console.error(error);
+    json(res, 500, { message: 'Internal server error', detail: error instanceof Error ? error.message : String(error) });
+  }
+});
+
+server.listen(PORT, () => {
+  console.log('========================================');
+  console.log(' FPGA Selection Agent MVP 已启动');
+  console.log('----------------------------------------');
+  console.log(` 本地地址: http://localhost:${PORT}`);
+  console.log(` 健康检查: http://localhost:${PORT}/api/devices`);
+  console.log(' 启动脚本: bash scripts/run-agent.sh');
+  console.log(' 冒烟测试: bash scripts/smoke-test.sh');
+  console.log(' 停止服务: Ctrl+C');
+  console.log('========================================');
+});

--- a/tests/selection.test.mjs
+++ b/tests/selection.test.mjs
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseSelectionRequest } from '../lib/parser/selection-parser.js';
+import { recommendSelection } from '../lib/selection-service.js';
+
+test('parser infers vision bridge requirements and industrial context', () => {
+  const parsed = parseSelectionRequest({ query: '低功耗 MIPI 双摄桥接模块，工业级，预算敏感' });
+  assert.equal(parsed.applicationId, 'embedded_vision_bridge');
+  assert.equal(parsed.hardConstraints.require_mipi, true);
+  assert.equal(parsed.businessContext.target_temp_grade, 'industrial');
+  assert.equal(parsed.extractedSignals.camera_count, 2);
+});
+
+test('recommendation returns PCIe/DDRx capable part for acquisition query', () => {
+  const response = recommendSelection({ query: '需要 PCIe Gen3 和 DDR4 的数据采集卡', topN: 3, team: { serdes_experience: true, ddr_experience: true } });
+  assert.ok(response.results.length >= 1);
+  assert.match(response.results[0].device.pcie_support || '', /Gen3|Gen4/i);
+  assert.ok(response.results[0].device.ddr_support.some((item) => /DDR4/i.test(item)));
+});
+
+test('stage comparison generates distinct guidance payload', () => {
+  const response = recommendSelection({ query: '工业电机控制，要求低功耗和长期供货', topN: 2 });
+  assert.ok(Array.isArray(response.stageComparison.summary));
+  assert.ok(response.stageComparison.summary.length >= 1);
+  assert.ok(response.results[0].stageAdvice.prototype.length >= 1);
+  assert.ok(response.results[0].stageAdvice.production.length >= 1);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "lib": ["ES2022", "DOM"],
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["types/**/*.d.ts"]
+}

--- a/types/domain.d.ts
+++ b/types/domain.d.ts
@@ -1,0 +1,166 @@
+export type PriceBand = 'low' | 'mid' | 'high';
+export type PowerProfile = 'ultra_low' | 'low' | 'medium' | 'high';
+export type LifecycleStatus = 'active' | 'mature' | 'legacy' | 'new';
+export type Stage = 'prototype' | 'production';
+
+export interface FPGADevice {
+  id: string;
+  vendor: string;
+  family: string;
+  part_number: string;
+  device_type: 'FPGA' | 'SoC FPGA' | 'Low Power FPGA';
+  logic_cells: number;
+  luts: number;
+  ffs: number;
+  bram_kb: number;
+  uram_kb: number;
+  dsp_blocks: number;
+  transceiver_channels: number;
+  transceiver_max_rate_gbps: number;
+  pcie_support: string | null;
+  ddr_support: string[];
+  mipi_support: boolean;
+  hard_cpu: boolean;
+  gpio_count: number;
+  lvds_pairs: number;
+  package_options: string[];
+  temp_grades: string[];
+  power_profile: PowerProfile;
+  toolchain: string[];
+  lifecycle_status: LifecycleStatus;
+  price_band: PriceBand;
+  availability_score: number;
+  community_score: number;
+  board_maturity_score: number;
+  board_complexity: 'low' | 'medium' | 'high';
+  recommended_for: string[];
+  not_recommended_for: string[];
+}
+
+export interface BoardRecommendation {
+  id: string;
+  name: string;
+  vendor: string;
+  device_ids: string[];
+  stage_focus: Stage[];
+  summary: string;
+  price_band: PriceBand;
+  maturity_score: number;
+}
+
+export interface TeamProfile {
+  fpga_experience: 'beginner' | 'intermediate' | 'advanced';
+  ddr_experience: boolean;
+  serdes_experience: boolean;
+  linux_experience: boolean;
+  preferred_toolchains?: string[];
+  preferred_vendors?: string[];
+}
+
+export interface BusinessContext {
+  stage: Stage;
+  budget_sensitivity: 'low' | 'medium' | 'high';
+  prioritize_supply: boolean;
+  prioritize_longevity: boolean;
+  target_temp_grade?: string;
+}
+
+export interface SelectionRequest {
+  query: string;
+  topN?: number;
+  applicationId?: string;
+  constraints?: Partial<{
+    min_logic_cells: number;
+    min_luts: number;
+    min_dsp_blocks: number;
+    min_bram_kb: number;
+    min_lvds_pairs: number;
+    min_gpio_count: number;
+    require_pcie: boolean;
+    require_ddr: boolean;
+    require_mipi: boolean;
+    require_hard_cpu: boolean;
+    max_power_profile: PowerProfile;
+    max_price_band: PriceBand;
+    preferred_package: string;
+    vendor: string;
+  }>;
+  team?: Partial<TeamProfile>;
+  business?: Partial<BusinessContext>;
+}
+
+export interface ExtractedSignals {
+  camera_count?: number;
+  required_pcie_gen?: number;
+  required_ddr_gen?: number;
+  toolchain_keywords: string[];
+  vendor_keywords: string[];
+  skill_warnings: string[];
+  requirement_summary: string[];
+}
+
+export interface ParsedConstraints {
+  applicationId: string;
+  inferredTags: string[];
+  hardConstraints: NonNullable<SelectionRequest['constraints']>;
+  teamProfile: TeamProfile;
+  businessContext: BusinessContext;
+  normalizedQuery: string;
+  extractedSignals: ExtractedSignals;
+}
+
+export interface ScoreDimension {
+  raw: number;
+  weighted: number;
+  notes: string[];
+}
+
+export interface ScoreBreakdown {
+  total: number;
+  weights: Record<string, number>;
+  dimensions: Record<string, ScoreDimension>;
+}
+
+export interface ApplicationProfile {
+  id: string;
+  title: string;
+  description: string;
+  defaultWeights: Record<string, number>;
+  preferredTraits: string[];
+  avoidedTraits: string[];
+}
+
+export interface StageAdvice {
+  prototype: string[];
+  production: string[];
+}
+
+export interface SelectionResult {
+  rank: number;
+  device: FPGADevice;
+  score: ScoreBreakdown;
+  reasons: string[];
+  advantages: string[];
+  risks: string[];
+  whyBetterThanNext: string;
+  cheaperAlternative?: FPGADevice;
+  productionAlternative?: FPGADevice;
+  toolchainAdvice: string[];
+  boardRecommendations: BoardRecommendation[];
+  stageAdvice: StageAdvice;
+  fitSummary: string;
+}
+
+export interface StageComparison {
+  prototypeTop?: FPGADevice;
+  productionTop?: FPGADevice;
+  summary: string[];
+}
+
+export interface SelectionResponse {
+  parsed: ParsedConstraints;
+  totalCandidates: number;
+  warnings: string[];
+  stageComparison: StageComparison;
+  results: SelectionResult[];
+}


### PR DESCRIPTION
### Motivation

- Deliver a runnable local MVP that helps engineers choose FPGA devices by combining natural-language parsing, hard-constraint filtering, multi-dimensional scoring, and human-readable explanations. 
- Provide a framework-agnostic, zero-dependency Node runtime so the app can start without `npm install` and can be migrated to Next.js later. 

### Description

- Add a lightweight Node HTTP server (`server.mjs`) and route handlers exposing APIs `POST /api/selection/{parse,search,rank,recommend}` and `GET /api/devices` plus device lookup. 
- Implement the full selection pipeline: parser (`lib/parser/selection-parser.js`), expert rules (`lib/rules/expert-rules.js`), filtering (`lib/scoring/filter.js`), scoring & ranking (`lib/scoring/rank.js`), and explanation builder (`lib/scoring/explain.js`) wired via `lib/selection-service.js`. 
- Ship sample datasets and board catalog under `lib/data` (`devices.json`, `boards.json`, `applications.json`) and TypeScript domain definitions (`types/domain.d.ts`). 
- Add a single-page UI and components (`app/page.js`, `components/*`, `public/app.js`, `public/styles.css`), documentation (`docs/*.md`), helper scripts (`scripts/run-agent.sh`, `scripts/smoke-test.sh`), package metadata (`package.json`, `tsconfig.json`), and basic tests (`tests/selection.test.mjs`).

### Testing

- Added unit tests (`tests/selection.test.mjs`) covering parsing, recommendation behavior, and stage comparison, and ran them with `npm test`, which succeeded (all tests passed). 
- Added a smoke test script (`bash scripts/smoke-test.sh`) that exercises `GET /api/devices` and `POST /api/selection/recommend`, and it passed locally confirming endpoints return expected payloads.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be5f0811608326a5811f19fd35ce51)